### PR TITLE
Evidence calibration

### DIFF
--- a/dot-pe_evidence_calibration_plan.md
+++ b/dot-pe_evidence_calibration_plan.md
@@ -1,0 +1,103 @@
+---
+name: Evidence Calibration Plan
+overview: Given a completed rundir from a real-event run, replace the data with Gaussian noise and recompute the Bayesian evidence. Starting point is a done rundir—do NOT call inference.run(). Load from rundir, swap in noise data, accumulate the grand-sum. Interpretation is out of scope.
+todos: []
+isProject: false
+---
+
+# Evidence Calibration: ln_evidence on Gaussian Noise
+
+## Goal
+
+Given a **completed rundir** from a real-event run, replace the data with Gaussian noise and recompute the Bayesian evidence. **Do NOT call `inference.run()`.** The starting point is a done rundir—load par_dic_0, extrinsic samples, bank indices, etc. from it, swap in Gaussian noise as the data, and run only the likelihood/evidence computation. Scope: swap the data, accumulate the grand-sum, get ln_evidence. Interpretation is out of scope.
+
+---
+
+## Prerequisites: par_dic_0 from Rundir
+
+We do **not** call `inference.run()` or `prepare_run_objects`. par_dic_0 is loaded from the completed rundir (already computed for the real run). No optimization on noise.
+
+---
+
+## Critical: No Optimization
+
+**The coherent posterior / likelihood objects must NOT try to optimize anything.** They should accept par_dic_0 as given and only compute the relative binning weights. No `find_bestfit_pars`, no fitting to the data—we are running on noise; any optimization would fit a waveform to noise, which is wrong.
+
+## Critical: Extrinsic Samples from Rundir
+
+Extrinsic samples are taken **directly from the rundir** (e.g. `rundir/extrinsic_samples.feather`). Not from elsewhere.
+
+---
+
+## Workflow
+
+### 1. Prerequisite: Completed Rundir
+
+A real-event run has already finished. The rundir contains par_dic_0, extrinsic samples, bank indices, bank configs, `run_kwargs.json`, `banks/<bank_id>/` with CLP state, etc.
+
+### 2. Create Gaussian-Noise EventData
+
+Use the same metadata as the real event so the setup is identical:
+
+- Same detectors, duration, PSD, `tgps`, `fmax`
+- No injection: `EventData.gaussian_noise(psd_funcs=..., tgps=..., ...)` or equivalent
+- The strain is pure Gaussian noise (different realization each time if you run multiple calibration runs)
+
+Example (cogwheel API):
+
+```python
+event_data_noise = EventData.gaussian_noise(
+    "",
+    detector_names=event_data_real.detector_names,
+    duration=event_data_real.duration,
+    tgps=event_data_real.tgps,
+    asd_funcs=...,  # same as real run
+    fmax=event_data_real.fmax,
+)
+```
+
+### 3. Load from Rundir, Swap Data, Compute Evidence
+
+- Load par_dic_0, extrinsic samples, bank indices, bank folders, etc. from rundir
+- Re-run the likelihood computation with `event_data_noise` (**no** `inference.run()`)
+- Accumulate the posterior contribution → ln_evidence
+
+Entry point:
+
+```python
+ln_evidence = compute_evidence_on_noise(rundir, event_data_noise)
+```
+
+### 4. Optional: Multiple Noise Realizations
+
+- Generate N independent `event_data_noise` realizations
+- Call `compute_evidence_on_noise(rundir, event_data_noise_i)` for each
+
+---
+
+## Difference from Regular Inference: Samples Not Needed
+
+Unlike a regular inference run (where individual samples matter for posteriors, corner plots, etc.), evidence calibration only needs the **grand-sum**—the log evidence. We do not need to keep the samples themselves. Just accumulate the posterior contribution (e.g. `logsumexp(ln_posterior)`). Light samples or other per-sample outputs that must be accumulated for normal runs are not important for this mode.
+
+---
+
+## Implementation Scope
+
+| Component | Responsibility |
+|-----------|----------------|
+| **Dot-pe** | New entry point `compute_evidence_on_noise(rundir, event_data_noise)`. Loads par_dic_0 and extrinsic samples from rundir. Coherent/likelihood objects accept par_dic_0 as given and compute relative binning weights only—**no optimization**. Returns ln_evidence. Does not call `inference.run()`. |
+| **Caller** | Create Gaussian noise EventData (same metadata as real event), call `compute_evidence_on_noise(rundir, event_data_noise)`. |
+
+---
+
+## Outputs
+
+- `ln_evidence` (returned by `compute_evidence_on_noise`; optionally save to file)
+
+---
+
+## Checklist for Caller
+
+1. Have a completed rundir from real-event PE
+2. Create `EventData` with Gaussian noise (same detectors, PSD, duration, tgps as real event)
+3. Call `compute_evidence_on_noise(rundir, event_data_noise)` — **not** `inference.run()`

--- a/dot-pe_evidence_calibration_support_14022804.plan.md
+++ b/dot-pe_evidence_calibration_support_14022804.plan.md
@@ -1,0 +1,153 @@
+---
+name: Dot-PE Evidence Calibration Support
+overview: Add a mode to dot-pe inference that runs the same pipeline as `run()` but accepts a pre-specified reference waveform (par_dic_0) and skips the ReferenceWaveformFinder optimization. This enables pure-noise evidence calibration without fitting a waveform to noise.
+todos: []
+isProject: false
+---
+
+# Dot-PE: Support for Evidence Calibration (No-Optimization Mode)
+
+## Handoff Context
+
+This plan is for implementing changes in the **dot-pe** repository to support "pure-noise evidence calibration." The caller (e.g. o4a-pe-project or any PE pipeline) will provide:
+
+- `EventData` (which may be Gaussian noise, not real strain)
+- A fixed `par_dic_0` (reference waveform parameters)
+- External extrinsic samples and bank indices from a previous run
+
+The goal: run the same inference pipeline as `run()`, but **skip** any optimization that fits a waveform to the data. The reference waveform must be taken as given.
+
+---
+
+## Use Case: Pure-Noise Evidence Calibration
+
+For evidence calibration, we run PE on Gaussian noise (no signal) using:
+
+- The same banks and extrinsic samples as a real-event run
+- A fixed reference waveform (e.g. median chirp mass from bank, q=1, chieff=0.5)
+- New relative-binning weights computed from that fixed reference
+
+The evidence from these noise runs is used to calibrate the Bayesian evidence. Fitting a waveform to noise would be wrong; we need a fixed reference.
+
+---
+
+## Current Behavior (Problem)
+
+In `prepare_run_objects`, dot-pe calls:
+
+```python
+coherent_posterior = Posterior.from_event(
+    event=event_data,
+    mchirp_guess=mchirp_guess,
+    ...
+)
+par_dic_0 = coherent_posterior.likelihood.par_dic_0.copy()
+```
+
+Cogwheel's `Posterior.from_event` uses `ReferenceWaveformFinder.from_event`, which **always** calls `find_bestfit_pars()` (except for injections with aligned spins). That method:
+
+- Runs differential evolution over mchirp, eta, chieff
+- Optimizes time, sky, inclination, phase, distance
+
+So the reference waveform is always optimized on the data. For pure noise, this fits a waveform to noise.
+
+---
+
+## Required Changes
+
+### 1. Cogwheel: Add `par_dic_0` bypass in ReferenceWaveformFinder
+
+**File:** `cogwheel/likelihood/reference_waveform_finder.py`
+
+In `ReferenceWaveformFinder.from_event`:
+
+- Add optional parameter: `par_dic_0: dict | None = None`
+- If `par_dic_0` is provided:
+  - Construct the finder with that dict
+  - **Do not call** `find_bestfit_pars()`
+- If `par_dic_0` is None: keep current behavior (call `find_bestfit_pars()`)
+
+The provided `par_dic_0` must have all required keys for the reference waveform (m1, m2, spins, iota, d_luminosity, sky, t_geocenter, f_ref, etc.). The caller is responsible for supplying a valid, self-consistent dict.
+
+### 2. Cogwheel: Wire through Posterior.from_event
+
+**File:** `cogwheel/posterior.py`
+
+In `Posterior.from_event`:
+
+- Add optional parameter: `par_dic_0: dict | None = None`
+- Pass it to `ReferenceWaveformFinder.from_event(..., par_dic_0=par_dic_0)`
+
+### 3. Dot-pe: Add `par_dic_0` support in prepare_run_objects
+
+**File:** `dot_pe/inference.py`
+
+In `prepare_run_objects`:
+
+- Add parameter: `par_dic_0: dict | None = None`
+- When `par_dic_0` is not None:
+  - Pass it to `Posterior.from_event(..., par_dic_0=par_dic_0)`
+  - Skip the usual ReferenceWaveformFinder optimization path (cogwheel will handle this)
+- When `par_dic_0` is None: keep current behavior (mchirp_guess only)
+
+### 4. Dot-pe: Expose `par_dic_0` in `run()` and `run_and_profile()`
+
+**File:** `dot_pe/inference.py`
+
+- Add `par_dic_0: dict | None = None` to the `run()` (and related) signature(s)
+- Forward it to `prepare_run_objects`
+
+---
+
+## API Summary
+
+```python
+# New optional parameter in dot_pe.inference.run()
+rundir = inference.run(
+    event=event_data,           # Can be EventData from noise
+    bank_folder=...,
+    extrinsic_samples=...,      # Already supported
+    mchirp_guess=...,           # Used only when par_dic_0 is None
+    par_dic_0=par_dic_0,        # NEW: when provided, skip ref-wf optimization
+    ...
+)
+```
+
+When `par_dic_0` is provided:
+
+- `mchirp_guess` is ignored for posterior creation (par_dic_0 takes precedence)
+- Cogwheel skips `find_bestfit_pars`
+- Relative binning uses the given reference waveform
+
+---
+
+## Caller Responsibility
+
+The caller (e.g. o4a-pe-project) must supply a valid `par_dic_0` when using this mode. It should include at least:
+
+- Intrinsic: m1, m2, s1z, s2z, in-plane spins (zero), iota, f_ref
+- Extrinsic: d_luminosity, lat, lon, t_geocenter, phi_ref, psi
+
+Example construction for "fixed reference" (median mchirp, q=1, chieff=0.5, no in-plane spins):
+
+```python
+m1, m2 = gw_utils.mchirpeta_to_m1m2(mchirp_median, eta_from_q(1))  # q=1 -> eta=0.25
+# s1z, s2z for chieff=0.5 with q=1
+# Plus extrinsic params (sky, time, phase, distance) - can use arbitrary valid values
+```
+
+---
+
+## Testing
+
+1. **Regression:** With `par_dic_0=None`, behavior is unchanged.
+2. **New path:** With `par_dic_0` provided and noise EventData, inference runs without calling `find_bestfit_pars`. Check that no optimization printouts appear (e.g. "Searching incoherent solution...").
+3. **Output:** Posterior.json, samples.feather, etc. should be produced as in a normal run.
+
+---
+
+## Dependencies
+
+- Cogwheel changes must be merged (or available) before or together with dot-pe changes
+- Dot-pe depends on cogwheel; the new `par_dic_0` argument is passed through to cogwheel's `Posterior.from_event`
+

--- a/dot_pe/evidence_calibration.py
+++ b/dot_pe/evidence_calibration.py
@@ -1,0 +1,483 @@
+"""
+Evidence calibration: compute Bayesian evidence on Gaussian noise.
+
+Given a completed inference rundir, replace the data with Gaussian noise and
+recompute the evidence. No optimization—par_dic_0 and extrinsic samples are
+loaded from the rundir.
+
+Uses a slim evidence path that does not store prob_samples or apply size_limit;
+it computes ln_posterior wherever the likelihood is non-negligible and
+accumulates logsumexp incrementally.
+"""
+
+import json
+from pathlib import Path
+from typing import Dict, List, Optional, Tuple, Union
+
+import numpy as np
+import pandas as pd
+from numpy.typing import NDArray
+from tqdm import tqdm
+
+from cogwheel.data import EventData
+from cogwheel.utils import read_json
+
+from . import likelihood_calculating, sample_processing
+from .likelihood_calculating import LinearFree
+from .utils import inds_to_blocks, parse_bank_folders, safe_logsumexp, validate_bank_configs
+
+# Threshold for dropping (i,e,o) combinations with approx lnlike below max - cut.
+# Large value = keep almost all non-negligible contributions.
+_APPROX_LNL_DROP_THRESHOLD = 30.0
+
+# O4 ASD function names per detector (cogwheel convention)
+_ASD_O4_BY_DET = {"H": "asd_H_O4", "L": "asd_L_O4", "V": "asd_V_O4"}
+
+
+def _create_noise_from_event_psd(
+    original: EventData,
+    seed: Optional[int] = None,
+    fmin: float = 15.0,
+    df_taper: float = 1.0,
+) -> EventData:
+    """
+    Create EventData with Gaussian noise using the original event's PSD.
+
+    Recovers ASD from wht_filter (asd = highpass / wht_filter) and generates
+    strain with the same spectral shape. No cogwheel asd_funcs needed.
+    """
+    from cogwheel.data import highpass_filter
+
+    highpass = highpass_filter(
+        original.frequencies, fmin=fmin, df_taper=df_taper
+    )
+    # wht_filter = highpass / asd  =>  asd = highpass / wht_filter
+    asd = np.divide(
+        highpass,
+        original.wht_filter,
+        out=np.full_like(original.wht_filter, np.nan, dtype=float),
+        where=original.wht_filter != 0,
+    )
+    # Bins with wht_filter=0 are excluded by fslice; use finite asd for generation
+    np.nan_to_num(asd, copy=False, nan=1.0, posinf=1.0, neginf=1.0)
+
+    duration = 1.0 / original.df
+    rng = np.random.default_rng(seed)
+    real, imag = rng.normal(
+        scale=np.sqrt(duration) / 2 * asd, size=(2,) + asd.shape
+    )
+    strain = real + 1j * imag
+    strain[:, [0, -1]] = strain[:, [0, -1]].real
+
+    return EventData(
+        eventname="",
+        frequencies=original.frequencies,
+        strain=strain,
+        wht_filter=original.wht_filter,
+        detector_names=original.detector_names,
+        tgps=original.tgps,
+        tcoarse=original.tcoarse,
+        injection=None,
+    )
+
+
+def create_noise_event_data(
+    rundir: Union[str, Path],
+    *,
+    event_path: Optional[Union[str, Path]] = None,
+    use_event_psd: bool = True,
+    asd_funcs: Optional[List[str]] = None,
+    observing_run: str = "O4",
+    seed: Optional[int] = None,
+) -> EventData:
+    """
+    Create EventData with Gaussian noise for evidence calibration.
+
+    Loads the original event from rundir. By default uses the event's own PSD
+    (recovered from wht_filter) to generate noise—no cogwheel asd_funcs needed.
+    Set use_event_psd=False to use cogwheel ASD models (asd_funcs) instead.
+
+    Parameters
+    ----------
+    rundir : Union[str, Path]
+        Path to completed inference rundir.
+    event_path : Union[str, Path], optional
+        Path to original event npz. If None, resolved from run_kwargs["event"].
+    use_event_psd : bool
+        If True (default), use the event's PSD from wht_filter. If False,
+        use cogwheel asd_funcs (requires asd_funcs or observing_run).
+    asd_funcs : list[str], optional
+        ASD function names per detector. Only used if use_event_psd=False.
+    observing_run : str
+        Observing run for default ASD names. Only used if use_event_psd=False.
+    seed : int, optional
+        Random seed for noise realization.
+
+    Returns
+    -------
+    EventData
+        EventData with Gaussian noise.
+    """
+    rundir = Path(rundir)
+    if event_path is not None:
+        event_path = Path(event_path)
+        if not event_path.exists():
+            raise FileNotFoundError(f"Event file not found: {event_path}")
+    else:
+        run_kwargs_path = rundir / "run_kwargs.json"
+        if not run_kwargs_path.exists():
+            raise FileNotFoundError(f"run_kwargs.json not found in {rundir}")
+        with open(run_kwargs_path, encoding="utf-8") as f:
+            run_kwargs = json.load(f)
+        event_path = Path(run_kwargs.get("event", ""))
+        event_dir = run_kwargs.get("event_dir")
+        if not event_path or not str(event_path).strip():
+            raise ValueError("run_kwargs.json has no 'event' key")
+        if not event_path.exists():
+            for base in [rundir, Path(event_dir) if event_dir else None, Path.cwd()]:
+                if base is None:
+                    continue
+                candidate = base / (event_path.name or event_path)
+                if candidate.exists():
+                    event_path = candidate
+                    break
+        if not event_path.exists():
+            raise FileNotFoundError(
+                f"Event file not found: {event_path}. Pass event_path explicitly."
+            )
+
+    original = EventData.from_npz(filename=str(event_path))
+    if use_event_psd:
+        return _create_noise_from_event_psd(original, seed=seed)
+    if asd_funcs is None:
+        asd_funcs = [
+            _ASD_O4_BY_DET.get(det, f"asd_{det}_{observing_run}")
+            for det in original.detector_names
+        ]
+    kwargs = {
+        "eventname": "",
+        "detector_names": original.detector_names,
+        "duration": 1.0 / original.df,
+        "asd_funcs": asd_funcs,
+        "tgps": original.tgps,
+        "tcoarse": original.tcoarse,
+        "fmax": original.frequencies[-1],
+    }
+    if seed is not None:
+        kwargs["seed"] = seed
+    return EventData.gaussian_noise(**kwargs)
+
+
+def _compute_evidence_per_bank_slim(
+    *,
+    event_data: EventData,
+    bank_path: Path,
+    top_rundir: Path,
+    par_dic_0: Dict,
+    inds: NDArray[np.int_],
+    n_ext: int,
+    n_phi: int,
+    m_arr: NDArray[np.int_],
+    blocksize: int,
+) -> Tuple[float, float]:
+    """
+    Compute ln_evidence for a single bank using a slim block-wise accumulation.
+
+    No prob_samples, no size_limit. Accumulates logsumexp(ln_posterior) over
+    blocks, keeping only (i,e,o) where approx distance-marginalized lnlike
+    is within _APPROX_LNL_DROP_THRESHOLD of the block maximum.
+
+    Returns
+    -------
+    ln_evidence : float
+    ln_evidence_discarded : float
+        Always -np.inf (we do not track discarded in slim path).
+    """
+    from cogwheel.waveform import WaveformGenerator
+
+    bank_path = Path(bank_path)
+    waveform_dir = bank_path / "waveforms"
+    bank_file_path = bank_path / "intrinsic_sample_bank.feather"
+    with open(bank_path / "bank_config.json", "r", encoding="utf-8") as f:
+        bank_config = json.load(f)
+        fbin = np.array(bank_config["fbin"])
+        approximant = bank_config["approximant"]
+
+    wfg = WaveformGenerator.from_event_data(event_data, approximant)
+    likelihood_linfree = LinearFree(event_data, wfg, par_dic_0, fbin)
+
+    intrinsic_sample_processor = sample_processing.IntrinsicSampleProcessor(
+        likelihood_linfree, waveform_dir
+    )
+    likelihood_calc = likelihood_calculating.LikelihoodCalculator(
+        n_phi=n_phi, m_arr=np.array(m_arr)
+    )
+    dh_weights_dmpb, hh_weights_dmppb = intrinsic_sample_processor.get_summary()
+
+    bank = intrinsic_sample_processor.load_bank(
+        bank_file_path,
+        full_intrinsic_indices=inds,
+        renormalize_log_prior_weights=False,
+    )
+    full_log_prior_weights_i = bank["log_prior_weights"].values
+
+    top_rundir = Path(top_rundir)
+    extrinsic_samples = pd.read_feather(top_rundir / "extrinsic_samples.feather")
+    full_log_prior_weights_e = extrinsic_samples["log_prior_weights"].values
+
+    response_dpe = np.load(top_rundir / "response_dpe.npy")
+    timeshift_dbe = np.load(top_rundir / "timeshift_dbe.npy")
+
+    n_total_samples = len(inds) * n_ext * n_phi
+
+    i_blocks = inds_to_blocks(inds, blocksize)
+    e_blocks = inds_to_blocks(np.arange(n_ext), blocksize)
+
+    running_logsumexp_ln_posterior = -np.inf
+
+    total_blocks = len(i_blocks) * len(e_blocks)
+    with tqdm(total=total_blocks, desc="Slim evidence blocks") as pbar:
+        for i_block in i_blocks:
+            amp_impb, phase_impb = intrinsic_sample_processor.load_amp_and_phase(
+                waveform_dir, i_block
+            )
+            h_impb = amp_impb * np.exp(1j * phase_impb)
+
+            sort_order = np.argsort(inds)
+            pos_in_inds = sort_order[np.searchsorted(inds[sort_order], i_block)]
+            log_prior_weights_i_block = full_log_prior_weights_i[pos_in_inds]
+
+            for e_block in e_blocks:
+                response_subset = response_dpe[..., e_block]
+                timeshift_subset = timeshift_dbe[..., e_block]
+                log_prior_weights_e_block = full_log_prior_weights_e[e_block]
+
+                dh_ieo, hh_ieo = likelihood_calc.get_dh_hh_ieo(
+                    dh_weights_dmpb,
+                    h_impb,
+                    response_subset,
+                    timeshift_subset,
+                    hh_weights_dmppb,
+                    likelihood_linfree.asd_drift,
+                )
+
+                (
+                    inds_i_k,
+                    inds_e_k,
+                    inds_o_k,
+                ) = likelihood_calc.select_ieo_by_approx_lnlike_dist_marginalized(
+                    dh_ieo,
+                    hh_ieo,
+                    log_prior_weights_i_block,
+                    log_prior_weights_e_block,
+                    cut_threshold=_APPROX_LNL_DROP_THRESHOLD,
+                )
+
+                if len(inds_i_k) == 0:
+                    pbar.update(1)
+                    continue
+
+                dh_k = dh_ieo[inds_i_k, inds_e_k, inds_o_k]
+                hh_k = hh_ieo[inds_i_k, inds_e_k, inds_o_k]
+                dist_marg_lnlike_k = likelihood_calc.lookup_table.lnlike_marginalized(
+                    dh_k, hh_k
+                )
+
+                log_prior_k = (
+                    log_prior_weights_i_block[inds_i_k]
+                    + log_prior_weights_e_block[inds_e_k]
+                    - np.log(n_total_samples)
+                )
+                ln_posterior_k = dist_marg_lnlike_k + log_prior_k
+                log_contrib = np.logaddexp.reduce(ln_posterior_k)
+                running_logsumexp_ln_posterior = safe_logsumexp(
+                    [running_logsumexp_ln_posterior, log_contrib]
+                )
+                pbar.update(1)
+
+    ln_evidence = running_logsumexp_ln_posterior
+    return ln_evidence, -np.inf
+
+
+def _run_evidence_slim_per_bank(
+    *,
+    banks: Dict[str, Path],
+    event_data: EventData,
+    rundir: Path,
+    par_dic_0: Dict,
+    selected_inds_by_bank: Dict[str, NDArray[np.int_]],
+    n_ext: int,
+    n_phi: int,
+    m_arr: NDArray[np.int_],
+    blocksize: int,
+) -> List[Dict]:
+    """Run slim evidence computation for each bank. Returns same structure as
+    run_coherent_inference_per_bank but with lnZ_k from slim path."""
+    bank_results = []
+
+    for bank_id, bank_path in banks.items():
+        inds = selected_inds_by_bank[bank_id]
+        n_int_k = len(
+            pd.read_feather(bank_path / "intrinsic_sample_bank.feather")
+        )
+        n_total_samples = n_phi * n_ext * n_int_k
+
+        if len(inds) == 0:
+            bank_results.append(
+                {
+                    "bank_id": bank_id,
+                    "lnZ_k": -np.inf,
+                    "lnZ_discarded_k": -np.inf,
+                    "N_k": n_total_samples,
+                }
+            )
+            continue
+
+        lnZ_k, lnZ_discarded_k = _compute_evidence_per_bank_slim(
+            event_data=event_data,
+            bank_path=bank_path,
+            top_rundir=rundir,
+            par_dic_0=par_dic_0,
+            inds=inds,
+            n_ext=n_ext,
+            n_phi=n_phi,
+            m_arr=m_arr,
+            blocksize=blocksize,
+        )
+        bank_results.append(
+            {
+                "bank_id": bank_id,
+                "lnZ_k": lnZ_k,
+                "lnZ_discarded_k": lnZ_discarded_k,
+                "N_k": n_total_samples,
+            }
+        )
+
+    return bank_results
+
+
+def compute_evidence_on_noise(
+    rundir: Union[str, Path],
+    event_data_noise: Optional[Union[str, Path, EventData]] = None,
+    *,
+    event_path: Optional[Union[str, Path]] = None,
+    use_event_psd: bool = True,
+    asd_funcs: Optional[List[str]] = None,
+    seed: Optional[int] = None,
+) -> Tuple[float, float]:
+    """
+    Compute Bayesian evidence on Gaussian noise using setup from a completed rundir.
+
+    Loads par_dic_0, extrinsic samples, and bank indices from rundir. Uses the
+    provided event_data_noise as the data. No optimization is performed—par_dic_0
+    is taken as given. Extrinsic samples are loaded directly from the rundir.
+
+    Parameters
+    ----------
+    rundir : Union[str, Path]
+        Path to a completed inference rundir.
+    event_data_noise : EventData, str, Path, or None
+        EventData with Gaussian noise, or path to noise npz. If None, creates
+        noise from rundir using create_noise_event_data().
+    event_path : str or Path, optional
+        Path to original event npz when creating noise (if run_kwargs resolution
+        fails). Only used if event_data_noise is None.
+    use_event_psd : bool
+        Use event's PSD when creating noise (default True). Only if
+        event_data_noise is None.
+    asd_funcs : list[str], optional
+        ASD functions when creating noise with use_event_psd=False.
+    seed : int, optional
+        Random seed when creating noise (only used if event_data_noise is None).
+
+    Returns
+    -------
+    ln_evidence : float
+        Log of the total evidence.
+    ln_evidence_discarded : float
+        Log of the discarded evidence.
+    """
+    rundir = Path(rundir)
+    if event_data_noise is None:
+        event_data_noise = create_noise_event_data(
+            rundir,
+            event_path=event_path,
+            use_event_psd=use_event_psd,
+            asd_funcs=asd_funcs,
+            seed=seed,
+        )
+    elif isinstance(event_data_noise, (str, Path)):
+        event_data_noise = EventData.from_npz(filename=str(event_data_noise))
+    if not rundir.exists():
+        raise FileNotFoundError(f"Rundir not found: {rundir}")
+
+    # Load par_dic_0 from Posterior.json (no optimization—taken as given)
+    posterior_path = rundir / "Posterior.json"
+    if not posterior_path.exists():
+        raise FileNotFoundError(
+            f"Posterior.json not found in {rundir}. "
+            "Rundir must be from a completed inference run."
+        )
+    posterior = read_json(posterior_path)
+    par_dic_0 = posterior.likelihood.par_dic_0.copy()
+
+    # Load run configuration
+    run_kwargs_path = rundir / "run_kwargs.json"
+    if not run_kwargs_path.exists():
+        raise FileNotFoundError(f"run_kwargs.json not found in {rundir}")
+    with open(run_kwargs_path, "r", encoding="utf-8") as f:
+        run_kwargs = json.load(f)
+
+    bank_folder = run_kwargs["bank_folder"]
+    banks = parse_bank_folders(bank_folder)
+    bank_paths = list(banks.values())
+    bank_config = validate_bank_configs(bank_paths)
+    m_arr = np.array(bank_config["m_arr"])
+
+    n_ext = int(run_kwargs["n_ext"])
+    n_phi = int(run_kwargs["n_phi"])
+    blocksize = int(run_kwargs["blocksize"])
+
+    banks_dir = rundir / "banks"
+    if not banks_dir.exists():
+        raise FileNotFoundError(f"banks directory not found in {rundir}")
+
+    # Load selected intrinsic indices per bank
+    selected_inds_by_bank = {}
+    for bank_id, bank_path in banks.items():
+        bank_rundir = banks_dir / bank_id
+        inds_path = bank_rundir / "intrinsic_samples.npz"
+        if not inds_path.exists():
+            raise FileNotFoundError(
+                f"intrinsic_samples.npz not found for bank {bank_id} in {rundir}"
+            )
+        data = np.load(inds_path)
+        selected_inds_by_bank[bank_id] = data["inds"]
+
+    # Verify extrinsic samples exist in rundir
+    extrinsic_samples_path = rundir / "extrinsic_samples.feather"
+    if not extrinsic_samples_path.exists():
+        raise FileNotFoundError(
+            f"extrinsic_samples.feather not found in {rundir}"
+        )
+
+    # Run slim evidence per bank (no prob_samples, no size_limit)
+    per_bank_results = _run_evidence_slim_per_bank(
+        banks=banks,
+        event_data=event_data_noise,
+        rundir=rundir,
+        par_dic_0=par_dic_0,
+        selected_inds_by_bank=selected_inds_by_bank,
+        n_ext=n_ext,
+        n_phi=n_phi,
+        m_arr=m_arr,
+        blocksize=blocksize,
+    )
+
+    # Aggregate evidence across banks
+    lnZ_values = [r["lnZ_k"] for r in per_bank_results]
+    ln_evidence = safe_logsumexp(lnZ_values)
+    lnZ_discarded_values = [r["lnZ_discarded_k"] for r in per_bank_results]
+    ln_evidence_discarded = safe_logsumexp(lnZ_discarded_values)
+
+    return ln_evidence, ln_evidence_discarded

--- a/notebooks/04_evidence_calibration/04_evidence_calibration.ipynb
+++ b/notebooks/04_evidence_calibration/04_evidence_calibration.ipynb
@@ -1,0 +1,589 @@
+{
+  "cells": [
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "# Tutorial 4: Calibrate the evidence values against noise"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "Evidence calibration computes ln_evidence on Gaussian noise using the same setup (par_dic_0, extrinsic samples, banks) from a completed inference run. This helps calibrate and validate the evidence: on pure noise, ln_evidence should be lower than on real data with a signal.\n",
+        "\n",
+        "**Workflow:**\n",
+        "1. Create mock data and bank\n",
+        "2. Run inference to produce a rundir\n",
+        "3. Run evidence calibration on noise (replace data with Gaussian noise, recompute ln_evidence)\n",
+        "4. Validate by running on the original event data to verify we reproduce the rundir's ln_evidence"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 26,
+      "metadata": {},
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "The autoreload extension is already loaded. To reload it, use:\n",
+            "  %reload_ext autoreload\n"
+          ]
+        }
+      ],
+      "source": [
+        "%load_ext autoreload\n",
+        "%autoreload 2"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "Import libraries and set up the artifacts directory."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 27,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "import sys\n",
+        "\n",
+        "sys.path.append(\"../..\")\n",
+        "import numpy as np\n",
+        "import pandas as pd\n",
+        "import matplotlib.pyplot as plt\n",
+        "from pathlib import Path\n",
+        "import json\n",
+        "import warnings\n",
+        "from cogwheel.utils import read_json\n",
+        "\n",
+        "warnings.filterwarnings(\"ignore\", \"Wswiglal-redir-stdio\")\n",
+        "\n",
+        "from cogwheel import data, gw_utils, gw_plotting, utils, prior_ratio\n",
+        "from cogwheel.gw_prior import IntrinsicIASPrior\n",
+        "from cogwheel.posterior import Posterior\n",
+        "from cogwheel.likelihood import RelativeBinningLikelihood\n",
+        "from dot_pe import inference, waveform_banks, config\n",
+        "from dot_pe.power_law_mass_prior import PowerLawIntrinsicIASPrior\n",
+        "\n",
+        "# Set up artifacts directory for all outputs\n",
+        "ARTIFACTS_DIR = Path(\"./artifacts\")\n",
+        "ARTIFACTS_DIR.mkdir(exist_ok=True)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Step 1: Create Mock Data and Small Bank\n",
+        "\n",
+        "We use the methods from tutorials 1 and 2 to create a bank and generate an injection. This tutorial uses a 2-detector (HL) setup for faster execution.\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 3,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "# Create 2-detector injection\n",
+        "eventname = \"event_with_signal\"\n",
+        "# Injection parameters (chirp mass, mass ratio, spins, sky location, distance, etc.)\n",
+        "chirp_mass = 20.0\n",
+        "q = 0.7\n",
+        "m1, m2 = gw_utils.mchirpeta_to_m1m2(chirp_mass, gw_utils.q_to_eta(q))\n",
+        "\n",
+        "injection_par_dic = dict(\n",
+        "    m1=m1,\n",
+        "    m2=m2,\n",
+        "    ra=0.5,\n",
+        "    dec=0.5,\n",
+        "    iota=np.pi / 3,\n",
+        "    psi=1.0,\n",
+        "    phi_ref=12.0,\n",
+        "    s1z=0.3,\n",
+        "    s2z=0.3,\n",
+        "    s1x_n=0.1,\n",
+        "    s1y_n=0.2,\n",
+        "    s2x_n=0.3,\n",
+        "    s2y_n=-0.2,\n",
+        "    l1=0.0,\n",
+        "    l2=0.0,\n",
+        "    tgps=0.0,\n",
+        "    f_ref=50.0,\n",
+        "    d_luminosity=2000.0,\n",
+        "    t_geocenter=0.0,\n",
+        ")\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "event_data = data.EventData.gaussian_noise(\n",
+        "    eventname=eventname,\n",
+        "    detector_names=\"HL\",\n",
+        "    duration=120.0,\n",
+        "    asd_funcs=[\"asd_H_O3\", \"asd_L_O3\"],\n",
+        "    tgps=0.0,\n",
+        "    fmax=1600.0,\n",
+        "    seed=20223001,\n",
+        ")\n",
+        "\n",
+        "# Inject signal\n",
+        "event_data.inject_signal(injection_par_dic, \"IMRPhenomXPHM\")\n",
+        "snr = np.sqrt(\n",
+        "    2 * (event_data.injection[\"d_h\"] - 0.5 * event_data.injection[\"h_h\"]).sum()\n",
+        ")\n",
+        "print(f\"Injection SNR: {snr:.2f}\")\n",
+        "\n",
+        "# Save event data\n",
+        "event_path = ARTIFACTS_DIR / f\"{eventname}.npz\"\n",
+        "event_data.to_npz(filename=event_path, overwrite=True)\n",
+        "print(f\"Saved event data to: {event_path}\")"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "# Create a bank for tutorial\n",
+        "bank_dir = ARTIFACTS_DIR / \"bank\"\n",
+        "bank_dir.mkdir(parents=True, exist_ok=True)\n",
+        "\n",
+        "bank_size = 2**16\n",
+        "mchirp_min = 15\n",
+        "mchirp_max = 30\n",
+        "q_min = 0.2\n",
+        "f_ref = 50.0\n",
+        "seed = 777\n",
+        "n_pool = 4\n",
+        "blocksize = 4096\n",
+        "approximant = \"IMRPhenomXPHM\"\n",
+        "\n",
+        "# Generate bank samples\n",
+        "powerlaw_prior = PowerLawIntrinsicIASPrior(\n",
+        "    mchirp_range=(mchirp_min, mchirp_max),\n",
+        "    q_min=q_min,\n",
+        "    f_ref=f_ref,\n",
+        ")\n",
+        "ias_prior = IntrinsicIASPrior(\n",
+        "    mchirp_range=(mchirp_min, mchirp_max),\n",
+        "    q_min=q_min,\n",
+        "    f_ref=f_ref,\n",
+        ")\n",
+        "pr_ratio = prior_ratio.PriorRatio(ias_prior, powerlaw_prior)\n",
+        "# preemptive bugfix: sometimes not all matching items are removed\n",
+        "prior_ratio._remove_matching_items(\n",
+        "    pr_ratio._numerator_subpriors, pr_ratio._denominator_subpriors\n",
+        ")\n",
+        "\n",
+        "print(f\"Generating {bank_size:,} bank samples...\")\n",
+        "bank_samples = powerlaw_prior.generate_random_samples(\n",
+        "    bank_size, seed=seed, return_lnz=False\n",
+        ")\n",
+        "\n",
+        "# Compute derived quantities and weights\n",
+        "bank_samples[\"mchirp\"] = gw_utils.m1m2_to_mchirp(bank_samples[\"m1\"], bank_samples[\"m2\"])\n",
+        "bank_samples[\"lnq\"] = np.log(bank_samples[\"m2\"] / bank_samples[\"m1\"])\n",
+        "bank_samples[\"chieff\"] = gw_utils.chieff(\n",
+        "    *bank_samples[[\"m1\", \"m2\", \"s1z\", \"s2z\"]].values.T\n",
+        ")\n",
+        "\n",
+        "bank_samples[\"log_prior_weights\"] = bank_samples.apply(\n",
+        "    lambda row: pr_ratio.ln_prior_ratio(**row.to_dict()), axis=1\n",
+        ")\n",
+        "\n",
+        "\n",
+        "\n",
+        "# Save bank\n",
+        "bank_columns = [\n",
+        "    \"m1\",\n",
+        "    \"m2\",\n",
+        "    \"s1z\",\n",
+        "    \"s1x_n\",\n",
+        "    \"s1y_n\",\n",
+        "    \"s2z\",\n",
+        "    \"s2x_n\",\n",
+        "    \"s2y_n\",\n",
+        "    \"iota\",\n",
+        "    \"log_prior_weights\",\n",
+        "]\n",
+        "samples_path = bank_dir / \"intrinsic_sample_bank.feather\"\n",
+        "bank_samples[bank_columns].to_feather(samples_path)\n",
+        "\n",
+        "# Save bank config\n",
+        "bank_config = {\n",
+        "    \"bank_size\": bank_size,\n",
+        "    \"mchirp_min\": mchirp_min,\n",
+        "    \"mchirp_max\": mchirp_max,\n",
+        "    \"q_min\": q_min,\n",
+        "    \"f_ref\": f_ref,\n",
+        "    \"fbin\": config.DEFAULT_FBIN.tolist(),\n",
+        "    \"approximant\": approximant,\n",
+        "    \"m_arr\": [2, 1, 3, 4],\n",
+        "    \"seed\": seed,\n",
+        "}\n",
+        "bank_config_path = bank_dir / \"bank_config.json\"\n",
+        "with open(bank_config_path, \"w\") as f:\n",
+        "    json.dump(bank_config, f, indent=4)\n",
+        "\n",
+        "print(f\"Saved bank to: {bank_dir}\")\n",
+        "print(f\"Bank size: {len(bank_samples):,} samples\")\n",
+        "\n",
+        "# Generate waveforms from bank samples (this may take a few minutes)\n",
+        "waveform_dir = bank_dir / \"waveforms\"\n",
+        "print(f\"Generating waveforms using {n_pool} cores...\")\n",
+        "waveform_banks.create_waveform_bank_from_samples(\n",
+        "    samples_path=samples_path,\n",
+        "    bank_config_path=bank_config_path,\n",
+        "    waveform_dir=waveform_dir,\n",
+        "    n_pool=n_pool,\n",
+        "    blocksize=blocksize,\n",
+        "    approximant=approximant,\n",
+        ")\n",
+        "print(\"Waveform generation complete!\")"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Step 2: Run inference\n",
+        "\n",
+        "Run full inference to produce a completed rundir. We need this rundir for evidence calibration (it provides par_dic_0, extrinsic samples, bank indices, etc.).\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "# Create a new rundir for streamlined run\n",
+        "event_dir = ARTIFACTS_DIR / eventname\n",
+        "event_dir.mkdir(parents=True, exist_ok=True)\n",
+        "event_data_path = ARTIFACTS_DIR / f\"{eventname}.npz\"\n",
+        "bank_dir = ARTIFACTS_DIR / \"bank\"\n",
+        "bank_df = pd.read_feather(bank_dir / \"intrinsic_sample_bank.feather\")\n",
+        "\n",
+        "n_int = len(bank_df)\n",
+        "n_ext = 1024\n",
+        "n_phi = 50\n",
+        "n_t = 128\n",
+        "seed_ext = sum([int(str(i) * i) for i in range(1, 10)])\n",
+        "blocksize = 2048\n",
+        "single_detector_blocksize = 2048\n",
+        "mchirp_guess = chirp_mass\n",
+        "# Run streamlined inference (run_and_profile wraps run() with optional profiling)\n",
+        "print(\"Running streamlined inference with inference.run()...\")\n",
+        "final_rundir = inference.run_and_profile(\n",
+        "    event=event_data_path,\n",
+        "    bank_folder=bank_dir,\n",
+        "    n_int=n_int,\n",
+        "    n_ext=n_ext,\n",
+        "    n_phi=n_phi,\n",
+        "    n_t=n_t,\n",
+        "    blocksize=blocksize,\n",
+        "    single_detector_blocksize=single_detector_blocksize,\n",
+        "    seed=seed_ext,\n",
+        "    event_dir=str(event_dir),\n",
+        "    mchirp_guess=mchirp_guess,\n",
+        "    preselected_indices=None,\n",
+        "    max_incoherent_lnlike_drop=20,\n",
+        "    max_bestfit_lnlike_diff=20,\n",
+        "    draw_subset=True,\n",
+        ")\n",
+        "\n",
+        "print(\"\\nStreamlined inference complete!\")\n",
+        "print(f\"Results saved to: {final_rundir}\")\n",
+        "\n",
+        "# Load summary\n",
+        "summary_path = final_rundir / \"summary_results.json\"\n",
+        "summary = utils.read_json(summary_path)\n",
+        "print(\"\\nSummary:\")\n",
+        "print(f\"  n_effective: {summary['n_effective']:.2f}\")\n",
+        "print(f\"  n_effective_i: {summary['n_effective_i']:.2f}\")\n",
+        "print(f\"  n_effective_e: {summary['n_effective_e']:.2f}\")\n",
+        "print(f\"  ln_evidence: {summary['ln_evidence']:.2f}\")\n",
+        "\n",
+        "# Load final samples\n",
+        "final_samples = pd.read_feather(final_rundir / \"samples.feather\")\n",
+        "print(f\"\\nFinal samples shape: {final_samples.shape}\")\n",
+        "print(f\"Final samples saved to: {final_rundir / 'samples.feather'}\")"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "# Create corner plot with true injection parameters\n",
+        "\n",
+        "# Compute true values for plotting\n",
+        "true_mchirp = gw_utils.m1m2_to_mchirp(injection_par_dic[\"m1\"], injection_par_dic[\"m2\"])\n",
+        "true_lnq = np.log(injection_par_dic[\"m2\"] / injection_par_dic[\"m1\"])\n",
+        "true_chieff = gw_utils.chieff(\n",
+        "    injection_par_dic[\"m1\"],\n",
+        "    injection_par_dic[\"m2\"],\n",
+        "    injection_par_dic[\"s1z\"],\n",
+        "    injection_par_dic[\"s2z\"],\n",
+        ")\n",
+        "\n",
+        "true_values = injection_par_dic | {\n",
+        "    \"mchirp\": true_mchirp,\n",
+        "    \"lnq\": true_lnq,\n",
+        "    \"chieff\": true_chieff,\n",
+        "}\n",
+        "\n",
+        "# Load standardized samples (created in previous cell)\n",
+        "samples_path = sorted(\n",
+        "    event_dir.glob(\"run_*/samples.feather\"),\n",
+        "    key=lambda x: int(x.parent.stem.split(\"_\")[-1]),\n",
+        ")[-1]\n",
+        "samples = pd.read_feather(samples_path)\n",
+        "\n",
+        "# Create corner plot\n",
+        "\n",
+        "params = [\n",
+        "    \"mchirp\",\n",
+        "    \"lnq\",\n",
+        "    \"chieff\",\n",
+        "    \"iota\",\n",
+        "    \"ra\",\n",
+        "    \"dec\",\n",
+        "    \"d_luminosity\",\n",
+        "    \"bestfit_lnlike\",\n",
+        "]\n",
+        "corner_plot = gw_plotting.CornerPlot(\n",
+        "    samples,\n",
+        "    params=params,\n",
+        "    smooth=1.0,\n",
+        ")\n",
+        "corner_plot.plot(max_figsize=7)\n",
+        "\n",
+        "# Add true injection parameters\n",
+        "corner_plot.scatter_points(\n",
+        "    true_values, colors=\"red\", marker=\".\", s=200, label=\"Injection\"\n",
+        ")"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Step 3: Evidence calibration on noise\n",
+        "\n",
+        "Replace the data with Gaussian noise and recompute ln_evidence using the same setup from the rundir. By default, `create_noise_event_data` uses the event's PSD (recovered from wht_filter) and we pass the resulting noise to `compute_evidence_on_noise`."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 21,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "eventname = \"event_with_signal\"\n",
+        "event_dir = Path(ARTIFACTS_DIR / eventname)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "Below: original event strain vs. simulated Gaussian noise in the frequency domain (one subplot per detector)."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 22,
+      "metadata": {},
+      "outputs": [
+        {
+          "data": {
+            "image/png": "iVBORw0KGgoAAAANSUhEUgAAAcgAAANCCAYAAADiFVx9AAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjMsIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvZiW1igAAAAlwSFlzAAAPYQAAD2EBqD+naQAAn0hJREFUeJzs3Xt8VPWB///XmUkyk8n9TkIuhDsYCBhALqKgGBpXWkGtu20RLLRaqizNtlaWfm2ldnHb6uLWhUpXi9afLb0s9EbFVOVSUYFAFOWiYCABEkIC5Epuk/n9MTBkyElIwpBJ4P18PKbNnPOZcz5nGOc9n8/5nM8xXC6XCxEREfFi8XcFREREeiMFpIiIiAkFpIiIiAkFpIiIiAkFpIiIiAkFpIiIiAkFpIiIiAkFpIiIiAkFpIiIiAkFpMg1bO3atRiGwa5du0zX33XXXQwYMKBnKyXSRyggRURETCggRURETCggRURETAT4uwIicvU5nU6am5vbLNfNfETap4AUuQ5MnDix3XVpaWk9WBORvkMBKXIdeOWVVxgxYkSb5d/61rcoLi72Q41Eej8FpMh1YMSIEYwbN67N8oiICAWkSDs0SEdERMSEAlJERMSEAlJERMSEAlJERMSE4dKFUCIiIm2oBSkiImJCASkiImJCASkiImJCASkiImJCASkiImJCASkiImLiupmLtaWlhRMnThAWFoZhGP6ujoiI+InL5aK6upqkpCQslvbbiddNQJ44cYKUlBR/V0NERHqJ4uJikpOT211/3QRkWFgY4H5DwsPD/VwbERHxl6qqKlJSUjy50J7rJiAvdKuGh4crIEVE5LKn2zRIR0RExIQCUkRExIQCUkRExMR1cw6ys5xOJ01NTf6uhlzHAgMDsVqt/q6GyHVPAXmey+WitLSUs2fP+rsqIkRGRtKvXz9dsyviRwrI8y6EY3x8PA6HQ19M4hcul4u6ujrKysoASExM9HONRK5fCkjc3aoXwjEmJsbf1ZHrXHBwMABlZWXEx8eru1XETzRIBzznHB0Oh59rIuJ24bOo8+Ei/qOAbEXdqtJb6LMo4n99LiBnz55NVFQU9957r7+rIiIi17A+F5CLFy/mlVde8Xc1erVp06axZMkSv+zb5XLx9a9/nejoaAzDoKCgwC/18Kf58+dz9913e577899DRLqvzw3SmT59Ops3b/Z3Na4pmzdvZvr06Zw5c4bIyMgr2tbrr7/O2rVr2bx5MwMHDiQ2NtY3lezD/u///o/AwEB/V0NEuqhHW5Bbt25l1qxZJCUlYRgGGzZsaFNm1apVpKenY7fbycrKYtu2bT1ZRblChw8fJjExkcmTJ9OvXz8CAtr+BmtsbPRDzfy3/+jo6A7vGuDv90Okr/jo2Bk2vH+Q+iZnj+yvRwOytraWzMxMnn/+edP169atY8mSJSxbtow9e/YwdepUcnJyKCoq6slq9im1tbU88MADhIaGkpiYyDPPPNOmzKuvvsq4ceMICwujX79+fOlLX/JcZ3fkyBGmT58OQFRUFIZhMH/+fMDdGrz55puJjIwkJiaGu+66i8OHD7dbl/nz5/Poo49SVFSEYRgMGDAAcHcxPvLII+Tm5hIbG8sdd9wBwJYtW5gwYQI2m43ExEQef/xxmpubPdubNm0ajz76KEuWLCEqKoqEhATWrFlDbW0tDz74IGFhYQwaNIi//e1vHb5HAwYM4KmnnmL+/PlERETwta99jc2bN2MYhtfEEAUFBRiGwZEjRwBYu3YtkZGRbNq0iREjRhAaGsrnPvc5SkpKPK9xOp3k5uZ63qPHHnsMl8vltf9Lu1jN6iMil3di84skfPQL9u4/0CP769GAzMnJ4amnnmLOnDmm65999lkWLFjAwoULGTFiBCtXriQlJYXVq1d3eV8NDQ1UVVV5PbrC5XLR2Nzil8elX7Ad+c53vsPbb7/N+vXreeONN9i8eTP5+fleZRobG/nhD3/IBx98wIYNGygsLPSEYEpKCn/4wx8AOHjwICUlJTz33HOAO3xzc3PZuXMnb775JhaLhdmzZ9PS0mJal+eee47ly5eTnJxMSUkJO3fu9Kx7+eWXCQgI4J133uGFF17g+PHj3HnnnYwfP54PPviA1atX8+KLL/LUU095bfPll18mNjaWHTt28Oijj/KNb3yD++67j8mTJ7N7925mzpzJ3Llzqaur6/B9+slPfkJGRgb5+fn8v//3/zr9/tbV1fHTn/6UX/3qV2zdupWioiK+/e1ve9Y/88wzvPTSS7z44ov84x//4PTp06xfv/6y2+1ufUSuZ2ENpQAElX/UI/vrNecgGxsbyc/P5/HHH/danp2dzfbt27u8vRUrVvDkk092uz5NThf/8/ahbr/+Snxz+mCCAi4/zL+mpoYXX3yRV155xdMqe/nll9vcIfurX/2q5++BAwfy3//930yYMIGamhpCQ0OJjo4GID4+3usc5D333OO1nRdffJH4+Hj27dtHRkZGm/pEREQQFhaG1WqlX79+XusGDx7Mj3/8Y8/zZcuWkZKSwvPPP49hGAwfPpwTJ07w3e9+lyeeeAKLxf3bLTMzk+9973sALF26lKeffprY2FhPq+uJJ55g9erVfPjhh0ycOLHd9+q2227zCrZjx461W7a1pqYmfv7znzNo0CAAHnnkEZYvX+5Zv3LlSpYuXep5r37+85+zadOmy2730vqISO/Ta0axlpeX43Q6SUhI8FqekJBAaWmp5/nMmTO577772LhxI8nJyV6tlNaWLl1KZWWl51FcXHxV6+8Phw8fprGxkUmTJnmWRUdHM2zYMK9ye/bs4Qtf+AJpaWmEhYUxbdo0gMt2XR8+fJgvfelLDBw4kPDwcNLT0zv1OjPjxo3zer5//34mTZrkdb3flClTqKmp8Qqv0aNHe/62Wq3ExMQwatQoz7ILn5cLXcad3X9nORwOTziCe+q3C/uqrKykpKTE6/0PCAjo1L66Wx8R6Tm9pgV5waUXSLtcLq9lnfl1DmCz2bDZbN2uR6DV4JvTB3f79Vci0Nq5i8Q70xVbW1tLdnY22dnZvPrqq8TFxVFUVMTMmTMvOzhk1qxZpKSk8Itf/IKkpCRaWlrIyMjo1qCSkJCQNnU3+7cG78/ApaM/DcPwWnahbHvdvu3t/0ILtfV7aDZrjdn+u9IF3tn6iEjv02takLGxsVitVq/WIrhbBpe2KnuCYRgEBVj88ujsLCqDBw8mMDCQ9957z7PszJkzfPLJJ57nBw4coLy8nKeffpqpU6cyfPjwNq2toKAgwD3g5IKKigr279/P9773PW6//XZGjBjBmTNnruQt9TJy5Ei2b9/uFTbbt28nLCyM/v37+2w/7YmLiwPwGnDT1Ws2IyIiSExM9Hr/m5ub25wDFpG+qdcEZFBQEFlZWeTl5Xktz8vLY/LkyX6qVe8WGhrKggUL+M53vsObb77JRx99xPz58z2tI4DU1FSCgoL42c9+xmeffcaf/vQnfvjDH3ptJy0tDcMw+Mtf/sKpU6eoqakhKiqKmJgY1qxZw6FDh3jrrbfIzc31Wd0XLVpEcXExjz76KAcOHOCPf/wj3//+98nNzfWq/9UyePBgUlJS+MEPfsAnn3zCX//6V9MRwJfzr//6rzz99NOsX7+eAwcOsGjRIt0yTeQa0aMBWVNTQ0FBgeeXemFhIQUFBZ5zWrm5ufzv//4vL730Evv37+db3/oWRUVFPPzwwz1ZzT7lJz/5Cbfccguf//znmTFjBjfffDNZWVme9XFxcaxdu5bf/e53jBw5kqeffpqf/vSnXtvo378/Tz75JI8//jgJCQk88sgjWCwWfvOb35Cfn09GRgbf+ta3+MlPfuKzevfv35+NGzeyY8cOMjMzefjhh1mwYIFnQM7VFhgYyK9//WsOHDhAZmYm//mf/9lmBG1n/Nu//RsPPPAA8+fPZ9KkSYSFhTF79uyrUGMR6WmGyxcnVDrpwowtl5o3bx5r164F3BMF/PjHP6akpISMjAz+67/+i1tuueWK911VVUVERASVlZWEh4d7rauvr6ewsNAzQYGIv+kzKdLWuy+6R3470seTedv93d5OR3nQWo8O0pk2bdplBzgsWrSIRYsW9VCNREREzPWac5AiIiKdEdjguwGDHVFAiohInxLQ2LWZ0bpLASkiIn1CcKAVgChHUI/sTwEpIiJ9gtXivkbcYuncteJXSgEpIiJiQgEpIiJiQgEpIiJiQgEpIiJiQgF5DZs/fz533333Vd/PD37wA8aMGXPV99MewzDYsGHDVd2Hv49RRHqeAvIa9txzz3mm8OtteiLUfOnb3/42b775pr+rISI9qNfdD1J8JyIiwt9VuGaEhoYSGhrq72qISA9SC7KP+/3vf8+oUaMIDg4mJiaGGTNmUFtbC7TtYp02bRqPPvooS5YsISoqioSEBNasWUNtbS0PPvggYWFhDBo0iL/97W+e16xdu5bIyEivfW7YsKHDe1bu3LmTO+64g9jYWCIiIrj11lvZvXu3Z/2AAQMAmD17NoZheJ4D/PnPfyYrKwu73c7AgQN58sknaW5u9qz/9NNPueWWW7Db7YwcObLN7dHMTJs2jcWLF/PYY48RHR1Nv379+MEPfuBVpqioiC984QuEhoYSHh7OF7/4RU6ePOlZf2kX6+bNm5kwYQIhISFERkYyZcoUjh492unjEJHeTwHZHpcLmhv98+jkDVZKSkr4l3/5F7761a+yf/9+Nm/ezJw5czqcEP7ll18mNjaWHTt28Oijj/KNb3yD++67j8mTJ7N7925mzpzJ3Llzqaur6/ZbV11dzbx589i2bRvvvfceQ4YM4c4776S6uhpwByjAL3/5S0pKSjzPN23axFe+8hUWL17Mvn37eOGFF1i7di0/+tGPAGhpaWHOnDlYrVbee+89fv7zn/Pd7363U3V6+eWXCQkJ4f333+fHP/4xy5cv94Sry+Xi7rvv5vTp02zZsoW8vDwOHz7M/feb3y2gubmZu+++m1tvvZUPP/yQd999l69//eueHw2XOw4R6RvUxdoeZxNs6/oNdH1i6r9BwOWnUiopKaG5uZk5c+aQlpYGwKhRozp8TWZmpueei0uXLuXpp58mNjaWr33tawA88cQTrF69mg8//JCJEyd2q/q33Xab1/MXXniBqKgotmzZwl133UVcXBwAkZGR9OvXz1PuRz/6EY8//jjz5s0DYODAgfzwhz/kscce4/vf/z5///vf2b9/P0eOHCE5ORmA//iP/yAnJ+eydRo9ejTf//73ARgyZAjPP/88b775JnfccQd///vf+fDDDyksLCQlJQWAX/3qV9xwww3s3LmT8ePHe22rqqqKyspK7rrrLgYNGgTAiBEjOn0cItI3KCD7sMzMTG6//XZGjRrFzJkzyc7O5t577yUqKqrd14wePdrzt9VqJSYmxitUExISACgrK+t2vcrKynjiiSd46623OHnyJE6nk7q6Os+NsduTn5/Pzp07vVpaTqeT+vp66urq2L9/P6mpqZ5wBJg0aVKn6tT6uAESExM9x7h//35SUlI84QgwcuRIIiMj2b9/f5uAjI6OZv78+cycOZM77riDGTNm8MUvfpHExMROHYfD4ehUnUXEvxSQ7bEGulty/tp3Z4pZreTl5bF9+3beeOMNfvazn7Fs2TLef/990tPTTV8TGOi9bcMwvJZd6CZsaWkBwGKxtOmybWpq6rBe8+fP59SpU6xcuZK0tDRsNhuTJk2isbGxw9e1tLTw5JNPMmfOnDbr7Ha7addxR+dCWzM77gvH6HK5TLfT3nJwdw8vXryY119/nXXr1vG9732PvLw8Jk6ceNnjEJG+QQHZHsPoVDenvxmGwZQpU5gyZQpPPPEEaWlprF+/ntzcXJ9sPy4ujurqamprawkJCQGgoKCgw9ds27aNVatWceeddwJQXFxMeXm5V5nAwECcTqfXshtvvJGDBw8yePBg0+2OHDmSoqIiTpw4QVJSEgDvvvtudw7LdLvFxcWeVuS+ffuorKz06jq91NixYxk7dixLly5l0qRJvPbaa0ycOPGyxyEifYMCsg97//33efPNN8nOziY+Pp7333+fU6dOdfil3lU33XQTDoeDf//3f+fRRx9lx44dl722cvDgwfzqV79i3LhxVFVV8Z3vfIfg4GCvMgMGDODNN99kypQp2Gw2oqKieOKJJ7jrrrtISUnhvvvuw2Kx8OGHH7J3716eeuopZsyYwbBhw3jggQd45plnqKqqYtmyZVd8jDNmzGD06NF8+ctfZuXKlTQ3N7No0SJuvfVWxo0b16Z8YWEha9as4fOf/zxJSUkcPHiQTz75hAceeADgsschIn2DRrH2YeHh4WzdupU777yToUOH8r3vfY9nnnmmU4NWOis6OppXX32VjRs3MmrUKH7961+3uUTiUi+99BJnzpxh7NixzJ07l8WLFxMfH+9V5plnniEvL4+UlBTGjh0LwMyZM/nLX/5CXl4e48ePZ+LEiTz77LOeAUgWi4X169fT0NDAhAkTWLhwoU9Ghl6YtCAqKopbbrmFGTNmMHDgQNatW2da3uFwcODAAe655x6GDh3K17/+dR555BEeeuihTh2HiPQNhqujawKuIVVVVURERFBZWUl4eLjXuvr6egoLC0lPT9c5IukV9JkUaWvvq49T09DM0AEpxNz+r93eTkd50JpakCIiIiYUkCIiIiYUkCIiIiYUkCIiIiYUkCIiIiYUkK1cmFlFxN/0WRTxP00UAAQFBWGxWDhx4gRxcXEEBQV1egozEV9yuVw0NjZy6tQpLBYLQUG9fzYnkWuVAhL3Bejp6emUlJRw4sQJf1dHBIfDQWpqKhaLOnlE/EUBeV5QUBCpqak0Nze3mSNUpCdZrVYCAgLUiyHiZwrIVi7c2eLSOz+IiMj1R/03IiIiJhSQIiIiJhSQIiIiJhSQIiIiJvpMQFZXVzN+/HjGjBnDqFGj+MUvfuHvKomIyDWsz4xidTgcbNmyBYfDQV1dHRkZGcyZM4eYmBh/V01ERK5BfaYFabVacTgcgPtmsk6nk+vkXs8iIuKlZ64R9llAbt26lVmzZpGUlIRhGGzYsKFNmVWrVnnukJ6VlcW2bdu6tI+zZ8+SmZlJcnIyjz32GLGxsT6qvYiIiDefBWRtbS2ZmZk8//zzpuvXrVvHkiVLWLZsGXv27GHq1Knk5ORQVFTkKZOVlUVGRkabx4Xp3yIjI/nggw8oLCzktdde4+TJk76qvoiIiBefnYPMyckhJyen3fXPPvssCxYsYOHChQCsXLmSTZs2sXr1alasWAFAfn5+p/aVkJDA6NGj2bp1K/fdd59pmYaGBhoaGjzPq6qqOnsoIiIiPXMOsrGxkfz8fLKzs72WZ2dns3379k5t4+TJk56Qq6qqYuvWrQwbNqzd8itWrCAiIsLzSElJ6f4BiIjIdadHArK8vByn00lCQoLX8oSEBEpLSzu1jWPHjnHLLbeQmZnJzTffzCOPPMLo0aPbLb906VIqKys9j+Li4is6BhERub706GUel96dwOVydfqOBVlZWRQUFHR6XzabDZvN1pXqiYiIePRICzI2Nhar1dqmtVhWVtamVSkiItIb9EhABgUFkZWVRV5entfyvLw8Jk+e3BNVEBER6RKfdbHW1NRw6NAhz/PCwkIKCgqIjo4mNTWV3Nxc5s6dy7hx45g0aRJr1qyhqKiIhx9+2FdVEBER8RmfBeSuXbuYPn2653lubi4A8+bNY+3atdx///1UVFSwfPlySkpKyMjIYOPGjaSlpfmqCiIiIj7js4CcNm3aZad+W7RoEYsWLfLVLkVERK6aPjMXq4iISE9SQIqIiJhQQIqIiJhQQIqIiJhQQIqIiJhQQIqIiJhQQIqIiJhQQIqIiJhQQIqIiJhQQIqIiJhQQIqISJ/i6uR9hK+UAlJERMSEAlJERMSEAlJERMSEAlJERMSEAlJERMSEAlJERMSEAlJERMSEAlJERMSEAlJERMSEAlJERMSEAlJERMSEAlJERMSEAlJERPoEF64e3Z8CUkRE+pSeuZeHAlJERMSUAlJERMSEAlJERMSEAlJERMSEAlJERMSEAlJERMSEAlJERMSEAlJERPqYnrkSUgEpIiJios8E5MGDBxkzZoznERwczIYNG/xdLRERuUYF+LsCnTVs2DAKCgoAqKmpYcCAAdxxxx3+rZSIiFyz+kwLsrU//elP3H777YSEhPi7KiIico3yWUBu3bqVWbNmkZSUhGEYpt2fq1atIj09HbvdTlZWFtu2bevWvn77299y//33X2GNRURE2uezgKytrSUzM5Pnn3/edP26detYsmQJy5YtY8+ePUydOpWcnByKioo8ZbKyssjIyGjzOHHihKdMVVUV77zzDnfeeaevqi4iItKGz85B5uTkkJOT0+76Z599lgULFrBw4UIAVq5cyaZNm1i9ejUrVqwAID8//7L7+eMf/8jMmTOx2+0dlmtoaKChocHzvKqqqjOHISIiAvTQOcjGxkby8/PJzs72Wp6dnc327du7tK3Odq+uWLGCiIgIzyMlJaVL+xERketbjwRkeXk5TqeThIQEr+UJCQmUlpZ2ejuVlZXs2LGDmTNnXrbs0qVLqays9DyKi4u7XG8REbl+9ehlHobhPfuBy+Vqs6wjERERnDx5slNlbTYbNputS/UTERG5oEdakLGxsVit1jatxbKysjatShERkQ51oWF1JXokIIOCgsjKyiIvL89reV5eHpMnT+6JKoiIiHSJz7pYa2pqOHTokOd5YWEhBQUFREdHk5qaSm5uLnPnzmXcuHFMmjSJNWvWUFRUxMMPP+yrKoiIiPiMzwJy165dTJ8+3fM8NzcXgHnz5rF27Vruv/9+KioqWL58OSUlJWRkZLBx40bS0tJ8VQURERGf8VlATps2DZfL1WGZRYsWsWjRIl/tUkRE5Krpk3OxioiIXG0KSBERERMKSBERERMKSBERERMKSBERERMKSBERERMKSBER6WOuoanmRERE+hoFpIiIiAkFpIiIiAkFpIiIiAkFpIiIiAkFpIiIiAkFpIiIiAkFpIiIiAkFpIiIiAkFpIiIiAkFpIiIiAkFpIiIiAkFpIiIiAkFpIiIiAkFpIiIiAkFpIiIiAkFpIiIiAkFpIiIiAkFpIiIiAkFpIiIiAkFpIiIiAkFpIiI9C2G0SO7UUCKiIiYUECKiIiYUECKiIiYUECKiIiY6JUBOXv2bKKiorj33nu7tE5ERMRXemVALl68mFdeeaXL60RERHylVwbk9OnTCQsL6/I6ERERX+lyQG7dupVZs2aRlJSEYRhs2LChTZlVq1aRnp6O3W4nKyuLbdu2+aKuIiIiPabLAVlbW0tmZibPP/+86fp169axZMkSli1bxp49e5g6dSo5OTkUFRV5ymRlZZGRkdHmceLEie4fiYiIiA8FdPUFOTk55OTktLv+2WefZcGCBSxcuBCAlStXsmnTJlavXs2KFSsAyM/P72Z1RUREeoZPz0E2NjaSn59Pdna21/Ls7Gy2b9/uy11dVkNDA1VVVV4PERGRzvJpQJaXl+N0OklISPBanpCQQGlpaae3M3PmTO677z42btxIcnIyO3fu7NS61lasWEFERITnkZKS0r2DEhGR61KXu1g7w7hkIlmXy9VmWUc2bdrUrXWtLV26lNzcXM/zqqoqhaSIiHSaTwMyNjYWq9XaprVYVlbWplV5tdlsNmw2W4/uU0RErh0+7WINCgoiKyuLvLw8r+V5eXlMnjzZl7sSERG5qrrcgqypqeHQoUOe54WFhRQUFBAdHU1qaiq5ubnMnTuXcePGMWnSJNasWUNRUREPP/ywTysuIiJyNXU5IHft2sX06dM9zy+c55s3bx5r167l/vvvp6KiguXLl1NSUkJGRgYbN24kLS3Nd7UWERG5yrockNOmTcPlcnVYZtGiRSxatKjblRIREfG3XjkXq4iIiL8pIEVEREwoIEVEREwoIEVEpE9x0fmJZ66EAlJERMSEAlJERMSEAlJERMSEAlJERMSEAlJERMSEAlJERMSEAlJERPqGjmc59TkFpIiI9ClGz1wGqYAUERExo4AUERExoYAUERExoYAUERExoYAUERExoYAUERExoYAUERExoYAUERExoYAUERExoYAUERExoYAUERExoYAUERExoYAUERExoYAUEZE+pmdu56GAFBERMaGAFBERMaGAFBERMaGAFBERMaGAFBERMaGAFBERMaGAFBERMaGAFBERMdErA3L27NlERUVx7733tlkXEBDAmDFjGDNmDAsXLvRD7URE5HoQ4O8KmFm8eDFf/epXefnll9usi4yMpKCgoOcrJSIi15Ve2YKcPn06YWFh/q6GiIhcx7ockFu3bmXWrFkkJSVhGAYbNmxoU2bVqlWkp6djt9vJyspi27ZtvqgrAFVVVWRlZXHzzTezZcsWn21XRESktS53sdbW1pKZmcmDDz7IPffc02b9unXrWLJkCatWrWLKlCm88MIL5OTksG/fPlJTUwHIysqioaGhzWvfeOMNkpKSOtz/kSNHSEpK4qOPPuKf/umf2Lt3L+Hh4V09DBERkQ51OSBzcnLIyclpd/2zzz7LggULPANoVq5cyaZNm1i9ejUrVqwAID8/v5vVxROgGRkZjBw5kk8++YRx48a1KdfQ0OAVwlVVVd3ep4iIXH98eg6ysbGR/Px8srOzvZZnZ2ezffv2K97+mTNnPKF37Ngx9u3bx8CBA03LrlixgoiICM8jJSXlivcvIiLXD5+OYi0vL8fpdJKQkOC1PCEhgdLS0k5vZ+bMmezevZva2lqSk5NZv34948ePZ//+/Tz00ENYLBYMw+C5554jOjradBtLly4lNzfX87yqqkohKSIinXZVLvMwDO+bWbpcrjbLOrJp0ybT5ZMnT2bv3r2d2obNZsNms3V6nyIiIq35tIs1NjYWq9XaprVYVlbWplUpIiLSPZ1vcF0JnwZkUFAQWVlZ5OXleS3Py8tj8uTJvtyViIjIVdXlLtaamhoOHTrkeV5YWEhBQQHR0dGkpqaSm5vL3LlzGTduHJMmTWLNmjUUFRXx8MMP+7TiIiIiV1OXA3LXrl1Mnz7d8/zCQJh58+axdu1a7r//fioqKli+fDklJSVkZGSwceNG0tLSfFdrERGRq6zLATlt2jRcLleHZRYtWsSiRYu6XSkREZF29cwpyN45F6uIiIi/KSBFRERMKCBFRERMKCBFRERMKCBFRERMKCBFRERMKCBFRERMKCBFRERMKCBFRERMKCBFRERMKCBFRERMKCBFRERMKCBFRERMKCBFRERMKCBFRERMKCBFRERMKCBFRERMKCBFRERMKCBFRERMKCBFRERMKCBFRERMKCBFRKSPMXpkLwpIEREREwpIEREREwpIEREREwpIEREREwpIEREREwpIEREREwpIEREREwpIEREREwpIEREREwpIEREREwpIEREREwpIERERE70yIGfPnk1UVBT33ntvm3U//elPueGGG8jIyODVV1/1Q+1EROR60CsDcvHixbzyyittlu/du5fXXnuN/Px8du3axerVqzl79mzPV1BERK55vTIgp0+fTlhYWJvl+/fvZ/Lkydjtdux2O2PGjOH111/3Qw1FRORa1+WA3Lp1K7NmzSIpKQnDMNiwYUObMqtWrSI9PR273U5WVhbbtm3zRV3JyMjg7bff5uzZs5w9e5a33nqL48eP+2TbIiIirQV09QW1tbVkZmby4IMPcs8997RZv27dOpYsWcKqVauYMmUKL7zwAjk5Oezbt4/U1FQAsrKyaGhoaPPaN954g6SkpHb3PXLkSBYvXsxtt91GREQE48ePJyCgy4cgIiJyWV1Ol5ycHHJyctpd/+yzz7JgwQIWLlwIwMqVK9m0aROrV69mxYoVAOTn53ezuvDQQw/x0EMPAbBw4UIGDx5sWq6hocErhKuqqrq9TxERuf749BxkY2Mj+fn5ZGdney3Pzs5m+/btPtlHWVkZAAcPHmTHjh3MnDnTtNyKFSuIiIjwPFJSUnyyfxGR60ZjLez7E5wt8ndN/MKn/ZPl5eU4nU4SEhK8lickJFBaWtrp7cycOZPdu3dTW1tLcnIy69evZ/z48QDcfffdnD17lpCQEH75y1+228W6dOlScnNzPc+rqqoUkiIiXfFpHg0nPiKo9COM2/7d37XpcVflBJ5hGF7PXS5Xm2Ud2bRpU7vrOtsStdls2Gy2Tu/T75obwdkAtrajd0VE/OFkWSmfFZ0lOiSIYf6ujB/4tIs1NjYWq9XaprVYVlbWplUpl3j3edj+PDRU+7smInIFXC4X9U1Of1fDJ45W1AFwurbRzzXx5upCg+tK+DQgg4KCyMrKIi8vz2t5Xl4ekydP9uWu+o6WFtj7e/hsS8flms8PKDpb3HZd0znf10tEror/232c1ZsPU17TdqR+XxNcX+bvKnhx9fD+utzFWlNTw6FDhzzPCwsLKSgoIDo6mtTUVHJzc5k7dy7jxo1j0qRJrFmzhqKiIh5++GGfVrzPOHsUyj91Pwbe2m6xqvomGppbCDrXyJ/fO8r4AdEM6xeG6/Db1B9+h4+dqRT3u427x/TvUne1iPSsotPuVtfe45VMHxbv59pcmZqGZn9XwZRBz3wHdjkgd+3axfTp0z3PLwyEmTdvHmvXruX++++noqKC5cuXU1JSQkZGBhs3biQtLc13te5LXC2dKvbxCfdlKMcLPiPiXBnbTo1g2KxbOf7BWxSfOQec5UjARM7UNREdEnQVKywiVyKm7jDRdUcwkj/v76rIFepyQE6bNg2Xq+OG7qJFi1i0aFG3K3UtaWyx8OHR00QEBzKkxQkWa4fl+1e4ByHF1h0Cbj0fjhe1XOa9FxH/GlL+JgC28gKgv1/rIlemV87Fei35tKyaJqeL8ppGGmoqrnh7ykeRvsHarLED3eU68FdcB/7q72ooIK9Iy+W7T131F2fwqXVe+VU1l2u9i0jvUHS67poZzdqTXA01fJy/jX3523A11vm1LgrILnC5XOwpOsN7+z6Dt1fAlv/E9d7qDoMytLzg4us7EagdGVn2lx4fxSUi3RN79kM27T50+YLipa6xmer6Zqrqm6lvurLvzCulgOyCY2fO8e7Hh3G9u4p3P6tgd9EZ3vv4MAc2/RyqTlws2FTv+bOh6eIosJaWdn5NdrJVGF5/AldDTbfqLiI9L/Tg7/1dhT7H2aohEfDROqiv9FtddCuMLkiJtDP2xG88zxua3f+QZ058xp4NKz2/dvpF2KkKHcSAW7/CsdO1OM6Xt5bswXX8DEbGPRDQaiRqF7pNjXNngNgrPRQR6QGOpjP+rkKfs/v9bVyYA82oKYWDf4PMf/ZLXRSQXeFs/8Lf1l0BpZX1UPkxeX/5Lf1b/QdycOffCbAY3BiRijV9SqtXd6HjtMF/v6ZERK42W/HF+wdX1zcT2VjXQ1c9tqUu1q4wuvZ29a/a02ZZc4uLjw4e5LNTrbpKuzBTjnHubJfqICLSVx0oraaown+nlRSQXeKb3zF1x/fxx4ITVJ5rck9Svv1nnd5ni0WTBIjI9ePEcf/daktdrF3RxRZkR1LPvs/bf9pGQs3+DstZDGhp1QPbHKpJ30VEeoICsit8GJBJVR9ctozL5cKFQetzlC36JxMR6RHqYu2KHp4kfMeG53FdMpdri0sXHouI9AQFZFf0cEC2nD7adqFm0hER6REKyD7GdvoTf1dBROS6oIDsov3xd/p1/0c+2ELD6WI+Ol5JXWPvvFebiMi1QCM+uqjSnuzvKrB7/XN8GnMbBx0OsoMPcKbmHP2nL8RqD/N31USuPpeLmoNvExgagy0509+18XItT07ucrmuu5u1KyC7aM6N/Tnhv8tyPIZUvAUV8NH555/+9r8ZkxZH9JAJ1NkTeL3QSWZKBIPjw9znLatLwRHjPcWdSB9UV17E3nc2AjBmbgbBQR3fY7Un7S485bdZX662qromIq6zm7Wri7WL0mJCiEsf7e9qtOFoOsMnhz7hs3/8jmNv/IwzJZ/x5w9KqGlopvHkAco2/5yqd37h72qKXLGKMxenb/zl2x91ULLn2U9d/vKtPus6nOZSLchuGDD1X6gq/ogmZ4vXRfy9QVm1e77YG2r/xGlHOr/dNJwRp/7mXnmqkPLQQoYnxzIkIYyyavddR+LD7P6qrkjXtRrJPfbYr4De080a0FhN+zM2920G/r31lLeeaacrILshIDCQsSmR1DQ289HxKq91hVE3U2lPYkzJb/1Uu4ui6wqJriv0WhZb8D+UF4BtbDavl4TiaKxgSkog6WHA0Jk9fimLSFe5rsG7ojpbXDQ0O3EE9d6vZKezNwVkz+i9/xq9nGEYOIICvKaC+yx6KmWhIwDoHxnM8bOdn4S8px3f8wajzv9dehpKgbI9xdiGTCPbmo8legCkToTqkxBoB3uE57UtTY2UFh8iIXUo1gB9hKSH9eZrgbv5+/K194/SUFHEF0dHEZ466vIv8IPT+94i6tYv+7saPUrfblfAahiMGxDNxpPRhDSVcypkiGddQriNEJuVQKuFD0obCGjp/R0v8bUHoeAgR8PtnKnbTUPz78lKiyLIaoFbH4OKQxCRzKbf/S+R9cW8F5bBnLs+D/ZIis/WU9foZFi/S0bSNlRDUKhapuI7rt7bkmlpNPlR7GwCa2CHryuvaWTiyT/xcR7cdP9SLKExV6mG3Vd2aA+DfBiQTc4WAizu74WzdU2E2gMItJoPi3E2N/PpwY+oa+zZUcIKyO7KmgcVh7CmTqZq13EOVdaDYTCqfwRRIYHYIh/EtvsVAD6NuZkRpzb6ucKdV1pV7/k7/+gZBseFUvLav1Pb4MRpBBLpagIgsfojil8/jDN2OOsbxgMQH2YjKiQIXC6ayj+jePNLuGKGknzLV7DhhLpyCEtUYEq3uXpxC/JcfduAdDqdWC8TkCENpzx/l5Sdon8vDMgONTfC8XyITMVlj6AWO6G2VvFyPB+AEmcEkfXHKLYP4Y2Py0iq/oBKe3/iaw5SFDmBwRWbCTXZ/I6XH/d63tJDnwEFZHeFJ7kfwD+NSmTdzmJuGhjDmJTIi2VSxkPNKSqbkjgYm02/mn2ENpzEej5gWosOCeJ0bWMPVb5rDrW6d+WldT925hyc2UNcdDhnglOprKkjomwHtQffunh+tmovbwUcZYH9bSy1ZTDiLuh3vhvJ5YKmc7QEBHOqpoG4UBsWyxWEZ2Mt1JRB1ACF8DWqN5+DtOBqM5TF2eLicheijDq53vO3q9lPp2Zazte8oRLske7/ji5xqKScg6eauDMjgfqGRj4pr2eorYKy7a9RVVNLXJiNwvLaTu0u6/z/J1a7RyJHnzvS6aoeP3mSuE6X7j4FpA9EOoJ46NZBbVcMnuH+/7xPOOMYQHP0YOrqahl/7GVPkcQIO2kxDnDBe4Wne6jGvjfo9BYASo5Dicn6AUd/z/uN7v/gMhs34HA24YofSdPeDQRVFrIt7E52nwkmpvYQN0bUEJKRw4DYUK8Lk10uFzTWYtjMfmO6Obc9R3NLC7bh2ZAywafHKL1Ebxs63ophEt6G0bX6WuvaBlNnuVqc1NY3EhJsxzAMWpwtGBYDo7meEzvW46g+SuOoL1FuRPHGR8cY3T+Cyn1v0e/83YUCrQZD4sPYV1Jluv1TG58mGnhv58VlBa3W1zT0zOxeRn3PXHKigOwBGf0j+Oh4Jf80OpHf7CjmvdSvM7FoDTckhRNmC8DAAAPGpUWx6+jFa7zOBKcSda4XzErgA6GNF/+j/+BYJRmuv/DR8dcASI12EPTZr5h4fn11BVR/toPPAqOJNSoZOnwUAWP/hU9+9wRVde5zuY47lpGZGgVAS4uL+mYnnxUfp/qI+0dGcMkfqEk8zuSbb8cSHN5zBypXnaW+9/6QtABtzpJd6A5scYLFCtWltBiBNNoi+fhEFSlRwV7F7cffwxUXx4fNqdQ0OJk8INQ99sdqo7nFhcUwqCjcw8EP3yOq/jgjEsNpchnQ4uT42XOcrLrMeIfj7hu03wRQDK333uR0tRuO1yMFZA+YMSKeW4bGYgvw7mgJtwe6W5mH/g6AdeBUOPonz/pPYmdwU/FLPVrXntL68pii03WmZRxNp6kDCj4sgA8LvNYd/8erWFuOU93OL9ZzTU6sRe/w/mvvsG/YN7lviEF4WDg4oqlvcmIPtMLJj6n5+HWsY79M8LlSiE73Gq3rpe40lBRA2hQIsEFTPRz5B2WucGojhzMgLoydR84QF2YjPTbEdBM1+9+k+VwlkWNnu7t/G+sgwA6WSwYm1FZAkAMCg023c72z1J/t2gtcLu/u9kufd9JHxyuJCgmif4SdynONfHi8irERdTQe2sw/6gcwKb6ZwMpCLj2B8sk76wkxGikp3Ndmm6dChvJxcApDWi07UFoNr7t/PFqA97aZ18cKVAHv9+Gep95OAdkDDMNoE475SV9m0sQBcLb9FqLr/ERH/cLtXgNnBKLOHaW6k2Ubqsr5+C/riAkJoqK2kbrAGBxNFUQGB3L2XBMU/pRwewBRjiD+EHwvzRYb8ZZKnLUVxNhdDMyYRMre/8FigHF4O58Me4ihxb/HqKvgcPFZAN6Oy8HicpJU/QGFkUnYBkyiMTCUwVEBxLVUYI9NZe9294QN/YMSSU2IgY/+QF1jM43jHiYyJMgdzrUVsGONu+JZ86F0L6RPbROWzeevSdtddJYBsQ4iggPbfMbaU1d1msCqIgL7jQRnI3TQZQ1A+SFoqHLXL3og1J6CkDh3yBTvwNVQTW30SEKjEzv5L+LtdG0jgVaDMPvFgSxlVXU0FeXTLyYKV/xIAloa4aPfQ/wI08s8Ks810eRswXF+2rn9JdUMjA3BUn+akP2/xdlvDLWhaUSf+ZCW0o95zzGNfo4WYqznWFcSzxjjMDdmjqHeFs2hMy18fLQE69kj3BZbTXPpR5yqbqCu0cm+iCxSKt0DTgKAvef3H8deDhW2qRYAVUcKaK9NFlf7CXG1ukNPb2W4evOQMB+qqqoiIiKCyspKwsP91+X2+/xjFJ+uY3B8KLMyk6DkQzjwVwBa0qbw/tvuFmRtUCx7+81hYtEaxg+I4khFHaeqe/+lInJRpT2ZiPpjAEQ6Ajlbd7FtEW4PoKr+Yuu3X4SdUyHDqD5VzLDQcziCrNgDrVgMgz3FZykNu4GIgVkMS0+j8Vwtn2z5DbbmKk6G3kC5YxA2Zw03D03A0XSafbVhRH/8MmfChnDcPpSpI5MZXL6Z6uhR7G4eQOD2/8LiambCgGgsFmiIy+T140EUWtKIqT3EdOe7xKVn8OfTKdxSu4nmFhcxIUHuYflWC7UNzQQHWXFExHHyZIlnUEZcaBDnYkYQFt2PI6dqONjcj6hzR6B/FrcFfsRu11DGDYhh29FzOD57neDaYqwtF98Tl2Fhd9KXiDpXxMDTW7v8flfZ+uG02KgNiqXcMYgmq4Pxx9Z27x9PejWrARO++tNuv76zeaCA7GH1TU4On6phcHyo+xf/qYPw0f8B0DLmy7z/f/8NwKGY6ZSHDGFi0RomDXQP+X73s4o22+sXbqP0cuccRESuIU3WYG6Z/8Nuv76zeaAu1h5mD7RyQ1Kr81wxQyAqDQIduCJSKEj8IqGNpyh3DL7stg7EfY5JYTsVkCJyXXEaPXNXEQWkv1ksMOZL7j9dLqyhMZQ3RLYt54gBLrYgK+3JpAweBUOncqZ6PcXWVEaX/l/P1FlE5DqggOxFDMNgwc0D+e83P/UsGzr5C9B8EkZ8niPH/8JZezKN1hBajAAeGhwDAQFM+9y9nDhbz6CPNvfpaylFRHoTBWQvY201i0xwkJWYEVM9z0vDMrzKBp2ft9ARFMDgeM13KiLiS7phci90Ybq6mwfHei0fGOe+vi42NIjPj0kioJ2JfUVErm09M7a0133DFhcXM23aNEaOHMno0aP53e9+51lXXV3N+PHjGTNmDKNGjeIXv/iFH2t69UwbFsfCqelk9Pe+aP3OUYncm5XMl29KY1DcZa5dA0KCrAwdnnHZcgCuHroBqYjIlTKb0u9q6HVdrAEBAaxcuZIxY8ZQVlbGjTfeyJ133klISAgOh4MtW7bgcDioq6sjIyODOXPmEBPTx2a+vwzD8L5o+oJAq4WUaEentpGWEEPSTfdAVBqFJ/9G+pl/eK2/9PKQ+sAIgpvOtru9KEcgZ+raTrIuInKt6nUtyMTERMaMGQNAfHw80dHRnD7tHnhitVpxONwBUV9fj9Pp7NW3vvGHcWlRjEhLIjHn2xA3FAJsnAwbydHIicSEuIdGH4zNJj0pniHx7lboZ9FTvbbRL9zm9XxAjANbYOdmaRERufp6aRfr1q1bmTVrFklJSRiGwYYNG9qUWbVqFenp6djtdrKysti2rZ3JBC9j165dtLS0kJKS4ll29uxZMjMzSU5O5rHHHiM2NraDLVx/Aq0WIiMiMFrdf+6rU9KZOnUaIefvz1YbFAtT/pXYCV/ks+hbKAsd4eliHRQXQnKUdys1zB7YZkJlERF/iQju+P6avtLlgKytrSUzM5Pnn3/edP26detYsmQJy5YtY8+ePUydOpWcnByKii7OOZqVlUVGRkabx4kTJzxlKioqeOCBB1izZo3X9iMjI/nggw8oLCzktdde4+TJk109hOtOhCOQ/lGhJITbsAdaGJsW6V6RMJKy0OHnS7kDMi7M5jWSNtIRSKgtgACLhUn3f5dJ8/6jZysvInKJ2NBeOlFATk4OOTk57a5/9tlnWbBgAQsXLgRg5cqVbNq0idWrV7NixQoA8vPzO9xHQ0MDs2fPZunSpUyePNm0TEJCAqNHj2br1q3cd999pttoaLh4jq2q6jq6hUuAzXyxxcLYlCgYaHbO1jj/vwaG4W5JulyQMH42HPwbDLkDQr1vUfppzG2kVu7A1uy+oXJCmI2TreaLLY4YR0rlrg6rWmVPIrz+4g+jKlsiBi2ENeiHj4j4l0/PQTY2NpKfn092drbX8uzsbLZv396pbbhcLubPn89tt93G3LlzvdadPHnSE3RVVVVs3bqVYcOGmW5nxYoVREREeB6tu2mvWTfcDWEJMOzOLr+02WrDFnDx4xAfZich3A5JY2BqLiSPa/OahoBQ9iR9yfP8wnnKvQl3c2DggxyPuJHdrdabKQsZ6vV8X8IsPk74QpfrLyLXj8je2sXakfLycpxOJwkJCV7LExISKC0t7dQ23nnnHdatW8eGDRsYM2YMY8aMYe9e901ljh07xi233EJmZiY333wzjzzyCKNHjzbdztKlS6msrPQ8iouLr+zg+oL4ETDuq+CIbrvu0vvhXSJyzBcYc8MNcMPsiwtDzp/fvaRFWuEYSG1QLDVB8QAciJuJCwMjIIhDMdOotcXzhQlDsAVaaAzo+HKUcscQXEavGysmIr1YgKVnLku7Kpd5GJfM6OJyudosa8/NN99MS0uL6bqsrCwKCgo6tR2bzYbNZt7VeF2ytPrFFdQ2tAJCo7DcMM/95NMQaKyFmEGmm/o0dobXTWdzbp0KrimU1zZRvs/dNRoZHMg3bh3Eyr9/ys7keQw/9TrljsH0q/nY+3ISw+CUYwjxtQdN9zUwNoTPzt9OqSNG/AiygksJsBp8UHyWc03mnyERuQb00NULPg3I2NhYrFZrm9ZiWVlZm1al9DCLBW5e4v5gWS/+s9sCLTQ0tZAWE3Kx7LgH4fRnEH+D6aZSox0Una7zPO8XYQeghXOtdnfxB5HTYvN0m5aFDuOm4pe8tlccMY7QxjJOho4EIMx+sX6BAe23Lg/GZjOs/A0AakJSCcyaCTUnMY79tt3XtN7n5c6Pikjv5AoKuXwhH/Bp31ZQUBBZWVnk5eV5Lc/Ly2t3sI30oMBgCPK+hGPhzQN5cMoAYkNbtbZtYZCY6RWkrf3T6ETiw9u2zi2d6CVwGe5tZiZHkJEUzvB+YTQFhPBh4n2cDLuBr0xMY+qQi4OBbB1Mp3fGMcB7QUQyRA4g2nFxhNu5wEjT1x4PH2O6PLWTEzGIiP80DJ99+UI+0OWArKmpoaCgwNPVWVhYSEFBgecyjtzcXP73f/+Xl156if379/Otb32LoqIiHn74YZ9WXHwjKMBCpKNrQ6btgVbuGp0EeA+3Tgi3kRbjYNQlU+SZcQQFEGYPJGdUotfp0bgwGx2dXnAEXWbCgpAYkqYv8ATdoehpbYocC78RDAuZyRfr+WG/OQD0j/TN9Z6loeat7/YCW0S6wNYzN73vchfrrl27mD59uud5bm4uAPPmzWPt2rXcf//9VFRUsHz5ckpKSsjIyGDjxo2kpaX5rtbidxHBgXxj2iDPHUXAfe55zo3JV7xtq8UgP+nLRNUXMzwtAo7/GYCz9mScY+dQ8vE/qLT3Jz02hOZjdgJa6ql1XNyvNXoAcWE2dzewyQCg5tgRfGv6UHjb/fF3WoKoC4olYcpcKNlISlQwxWfOtXkdAI4YTloSSKjZ1279nZZAQvsNJLBwH01O73Mln8bc1qX7dkYEB1J5TlP8ibQWfLkfyj7S5RbktGnTcLlcbR5r1671lFm0aBFHjhyhoaGB/Px8brnlFl/WWXoJe6DV61xjR6Ic7Q/LHpoQBuC+rAQYEBNCcr940kdNxpky0VOuKPImRg1I5FjkOBLThvKFMUnsTvoS+f2/ghHs3WoNslraTJl3QetRs1GOQJxGIGkxDgaenwC+9UxCA2IcxIfZGBDj4IakcG66/3FunPHP1A2+y3PXlUtVOAZxY1o0/c4fT2t3TRnLmZFfJr//V9p9P1oza9G+n7KAKnuS1zEEWq98VN+RqElXvA2A+LCrPzguI6lnWhDS+yRG2LH30NSXGl8vV9WFKaGG9QtnbGokANEh3l26t4+I546RCcwe2x9wD/C5e2x/Jg+O9cwf69meI5BHbxvMnaP6YRgGM0b1JzIyiluHek9iAJAeG0pGcmSH9RscH8qwfmHcOSoRLN4dKsfDxxJotTAoLpTEiGDC7YFYLAapMQ5uv3Uawa3+I3VaLtbzSORkMIw2I7dTox30jwwmZ+IYFt4+qsN6tfZe6tepcAz0PHcZVj6JuZ1jEVkADO8X7nX+N8we0OHUgJ/G3Ga6vDRsFGeCU6m0t+0FuHTmkva6ogfHhzIoLvSqBVhCmI2b0qNNJ/NvT1yo7wK7wXr5u+hc7z5IbDtxS2ecCM/kSJT5WJUL3wPxYe7TOD1FASlX1T9PSOGfRicyIT2aqUPiuOfGZPfNnVuxBVjJ6B9h2m1idnlQgNXiWX5DUgRfmZjWwdyMF19/4Ut98qCLMwkFWNwtTXugFSJTPV2y76UspDhyPIGdvOfmqZAhnr9bLAFe+73gwg8DwzC8fgGfTLvLq9y5wEichvt4wuwBTBkcy+ngAV5lmq3B3Jo9m5vS3de8Dk0IozT+ZoJu+y4ZSREkRzkIOz/37tlLAu9cYCSOIKtpC/hg3OfYH39xoomI4EAyksIZGOv9bxbQqsWa3CqML4RR2ICxDE3wTZhMSI9mQIyDsamRDIwLNR0MdqG1vjfh4uANiwGj+kf49Au1IOl+n22r0er7L/rgLrSsChK/2OH6iOBAjkRNYmf/B3gvZSF1gVGedUGX/HfR+gfUuVblOuuDfvdSFHkTpWEZ7Or/QJv1A+NCmDQwhkFxoRg9eGu+Xne7K7m2OIICPF2oAKkxDu9JC66WpDHQUEOTLYYL/+mmRjtIirQTENvOF7dhwLTvApBTWkVFTSPhlWlQdcK8fCupN0yi8b2PPZMnuFpda3ooZjqDK95ud/CRYfH+Uvug333E1B0ms3oLFsM99V+Fw31Nak1QHCMSwxiVHEl8uN3zXobaArh7zGCMfnEQcT8cfZdPAjMor6ylLjCSKUMSKPh4H+cCIhiZmkDmhAVgj4Din7Spz23D46k7P3Xy0IRQAiwWSLgBjmwF8JqrF9y/6o+dOec1ExPD7yLo6J422+7OOVWrYZAY0bbFmpkcwdlzTcTf9gglf/8Z9QER7on4z5uQHn3ZL9MqWyLhDSWm6+wBFo7ZhzAx+Dg1DU2UVjXgMrz/rW5MjWR30dkO97Ej+auENZQy4tRGr+Uf9ruHZmswE4vc800XRU4g9eyODrfVkeiQIIZNmsWendvYZx3GwNPum0SUZy2hBYPPTtUysGIL8bUHiQkJov4yA8aG3HgrpYyltLgScAefo+kMY1Mi2VdycerOQXEhxITYKK853e620mNDKOzE9cwAzdaLpyZG9Y+gxeUiICoFKo936vW+pICUnmcNAGfz1d3HMPd8wcYnp9jVfy5Bzjomsdn9ZX8hoIPOT4gQNaDNy4f3O99FuLtzYd4UHMfIe77HSzvc1wC3hCYQOyaHdw/WUm5NJatfALa0RNPXOgItJEbYqTzXxKC4UN4zDJyWQO/ZQgyDipDBAIxMjDDt4jTiR7j/iB4I0QOxFhyn9py73Pj0GP5xKOHCpty3QgPO2lOIrPeeZWp0cgTvDLiV+FPvEpA0GkLiIWUCBUf6EdJYzvAzb3uVtwVYGZcW5R2chuG5I5HTEoi1xR2Kg+NDyT965jLvZgem5sIHv4GqEziCAnAEBUB4PMcyl1DwWYX3+9EqHFvfz/REeCZJVR8wun8Erwb9E86GGiwtzaRW7iDqnPuXgT3QPW/x2Olfg7dXEBdmIz19MO+dr3q4PYCkyGBsAVb3MTUPJOL0h4C7NyGu9lPPvlssAVQGX2zFH46+lQrHoPM9Dd4Ko6aQfuYdz/NPYmcwuGIz5SGDsTVXE1HvDolAq+EZADa8XxhNzhZ3D0XaJEYkTWDz5sPUBUbTZLEzPtJBTUOz59jjaw8yYNRkHkwfwP6iNlXwCLQY3DY0gQ/OByS4w/DS83/xYRcD7VDMdEYmhRN3OohTNY2e5SE279ccjZxIQ0AoQ8v/3u7+R/ePIGTIFHDEQuwQKN4BR7e7p9TsIQpI6XmZX4KDG2HwjE4VbzGsWFxO6gMuf/mImWZrMM3WYPdUfC3NF4eIZ82DUwfd13x2U1KEnYraRkamRLq/OIwywP3lbEufxD0DLswiNbTdbRiGe2DSBXeOSGRnYRBpqXUQm4yt1ZmQWZlJ7la4mUtaorcNj6fJebJNV2rrBvyZ4LQ2AWkYBjffPguaZrivnT3vxuGD2H4ogoHWHTQ6W81UFGAjcPQX4NQBKPnQs9hsIIXFACNuGK5TB7GERFNKnGcWpZKwUZx2pHPDyT95v2jUve4vx/Rb3NMeZs2D/JfbbdkfzXiEnIpXvJYNjHMHs9ViUB2UQEDyjYQMTeah9OH8V94nnnITB0ZzrtGJLaDjrspQewBR5y+Pigu18blBwyirTmPfrs0UR4z3CsgLykKGEd5QahqO0SFBZI5N4YVD0UTWHyPq3FHC7QGcdgxkR/AA5mSl0NjkpPyvywHISovivc/O3yfXYhDlsLtvKMDF973G5v5B1HrSmfrASMKylxKU4u5ZmTDr6+z4s/cdkzwuma0mNdpBXJC7C73SkYa9qvDiyonf4L2mk2AYJAdYGBwfhi2wjmNnzpEW7cAR6H28JeHeU4Q2W7zPEydHBbtvzxfaDxLcE4gw8FZIuQkC2w5+u1oUkNLzIvrDhK91uviu/vMwaDH9xd0ll/7ytEdAyoSOXxM3osOunbSYEFJjHBjtnPvp7BSLjP0K7HkVgGH9whjWLwwYAICjrMZT7NLzt1gC3KFvcjlLmD2Qe7PaDrhp3bJydVS/QO9W6k0DYxiTGoltm40TZy+5DCZmENRXegVkoNV9rakREETBkVOAu7t0wsgh1MbdQ7AjlOffPkR5yGDOBUSSnpRAdVkNaTEOjla4Z2pqcCS6Ww+xQ7z3N+g29/uV6h7l3Pow/vmmAfD2+XPS53srguKHMmlIf6g6wYQbZrhnljJhYLhbpQATvt7+e2My01n8Dbfy/51w9xKcDB3J7eHHcAFNaVHkHz3DZzG3ek3R+JWJaRgGlIbczqCgUwSkjYPDhVTbEtwBeeG8umHxzHQVFhtCgMXAwHB3kzY7CR04EQZO9fr3+vLEVP6/99zNw0tvKp+RcvEcvDV+KAM+9wgH89ZSFDmBIRVvXSx4yd174uL7YZx1d0cf7pdDU0i5u3zGHAiO9Pw4vPDeJEcFE5s8hGBrC1SVMGFANDuOeHfDHoj7HNaWRpoCQvj6LQNZs/Uz94oxXwHrafeP2tZ6MBxBASl9wJUE4xWf7uyfBS4nHH673SJXOmjAAAhPAns4BLZtHQ6KC+HGtCjTy0YY+xU4/BYMmt52XSdcGAzUWRdaVlEhQRw9XecerOF5k9umhiMoAKwWxqVFYRjuHwyGI4KwCPfgon6RoZRUuv99c0YlMqG2kdhddsLsARSfPkf8bf9sXpHIFLjl22Btp/5jvgRVxyF5PJwudHejB5hPiDFlcCzvHConeuQ0OPNX6DcKhmS3LX/+OM/ak0mivN33CMBpBHhG2k4dEsu4Ae6BKy9s+cxTJu785TCxky/ePjAxwg4d3Jmv9WdgaEIYLlwY9rA2P2Zad3uG2AKoa3K2u83E/gMI/uK/M7yphcLfuwOy0RoCiWMB9+C28toGYkZOg6MGxA7F2Oduje7tN4cZcea9IwYGwVGJ7pbt2yvanLsGOBuc6lXPeZMHUFHTQHJ8aM+MVbgMBaT0ehfOt1x6HqNHWCzuVkpInLvFeRUY4O4evekbpl8KhmGYXsYCQHgijP1yl/YX1+o6xdOOdM7UpVFt69f5DSSPJ7jiU25MdY8o9ozYbW/+6IBgAi+cc06bDP0udmmH2C5+BVkshrtuAXbCaGBkYiAk9G+/Hq3CMSTokq+yqDT3AzznW9szfkAUwxLCCA8OAOcwsAZd9su5zaFe8iPOPQDG3fNgGBdbpf0i7JRW1re7XYthtPs2Au4WVdl+iB8OcSMwKj41vRUduLvji8/UMTIxnC2fnurweC7MpnWh07QkLMPTyr5vXDItrvODs4bOPF+isO1GznN1cARZaVE0NbcQl5lIoNXC/+327p2JDglqcxmYPykgpdf74vgU3vvstNflGT3O7M4mVzjYqCEgFFtzDU2h5y/6b6fbz1e+dFMqx86cY2TixWsUHfYgDsbNZNyAKE4cOcOA2E5cejBkBgy+Hdvmp93PO2hBAu4RsE11EJECid7nnqYPj6e5pYXM1terjvmSu1U8cFqnj+2GpHBO1dSTEtX1SycMwyDiwkQW7dxsvF0Db4WKw22OqyxkKAyMdV861Hpfl9lcR+ECwPB/cr+fUQPcPxDih7dbdHB8qKdL/sbUKD4oPssNSZ37kdd6tK5hGHR7HopLuneDrBaCrO5zlCWV7cxW1YsoIKXXiw+z8/nMpMsX7Gljvgyf5rnPh3VD5LRH+ehYBV8YfuXT83VGQrjdM1vRBQ9OSaeu0Um4PYCRieGdn5fXrIUVfX4ygwvniQbcDGX73C3wQPOJBUJtAcwee8nxh/Vzh2QXWCwGtw3vmTsGeR152mT3o00hi/nyTqgNjG1/pTWw7fnYTogIDuTR24aYdnO2diwii8hzRZSFtB+84Pv7Mfr1x28HNFGASHeFJ7lHVEamdOvlY9Ji+MqUoV2aFcbXAq0WIoIDMQyDmFDbZb9AvYSfv2wlIcP9/45omLQIJn7T/Tx9Ktz0ULvheC260GJrfe1vazemuc9Fpse2f7umyuBkPo29HceUh4COp2nsis782w69KYeP+s3mjlEd/2jLyehHmD2AmTdc7Jq/MFnHkHjzY79UbKgNi2EQERzITQN7Z0CqBSnXtJ6cdeO6M/qf4exRiG7V/XyVztP2FTNv6MfwfrXe91dtZWhCGPFTbIS386PoQo9khWMQMQnJfO2WZuwd3BPV1zJTIhmRGE7QZfYZH25n4dSBXsvmTkqj6lwTMZ2c2i/QauGb0wd16jZ5/qKAFJHuCbRD3DB/18Iv2muNBQVYGNJO6/GCjrqxLz0DGWrr+a/oy4VjewKtFpNwPH9EgcHQdP6cY6vzvAGdnMrRXxSQck3rxT9OpQ+aeUM/zp2zkRRy/XQb+8TYufDJ36DFCcPuvHz5XkIBKXIVdPdXuPRuI5PCIS0KTp/1d1X6lpAY9zW7fYwCUsSHsm9IoKG5pYO7i0jfdfW7I1yXucqjz+njB6SAFPGhzl5nJn2YI9Y9O49c8xSQIiJdkT7VPalDXMfXCnbHZScK6HP69vEoIOWapjE64nMBtm5PDiF9i0YSyDXN4uMZP+Q61t7E6HLNUkDKNW1MSiSxYbZeO5WV9AEj7oKQWBj6uau+qws3wu7SjEZy1aiLVa5p9kArcyem+bsa0pf1G+V+9IDJg2IJswcyOC708oV7M8Nwj2CNGuDvmlwRBaSISC8RFGAh6/x8rX3apG9CTdnFCez7KAWkiIj4li3M/ejjdA5SRETEhAJSRETEhAJSRETEhAJSRETEhAJSRETEhAJSRETEhAJSRETEhAJSRETEhAJSRETEhAJSRETEhAJSRETEhAJSRETExHUzWbnL5QKgqqrKzzURERF/upADF3KhPddNQFZXVwOQkpLi55qIiEhvUF1dTURERLvrDdflIvQa0dLSwokTJwgLC8MweufdusePH8/OnTuvmf36Yrvd3UZXXtfZsp0p11GZqqoqUlJSKC4uJjw8vFN16+389Zm9mvv21+e2q6/R57b7xo0bx1tvvUVSUhIWS/tnGq+bFqTFYiE5Odnf1eiQ1Wr1ywfwau3XF9vt7ja68rrOlu1Muc6UCQ8Pv2a+aPz1mb2a+/bX57arr9HntvsCAgI6lQcapNOLfPOb37ym9uuL7XZ3G115XWfLdqacv/4N/cWfx3utfW67+hp9bruvs8d73XSxivhbVVUVERERVFZWXjO/xOXadz1/btWCFOkhNpuN73//+9hsNn9XRaTTrufPrVqQIiIiJtSCFBERMaGAFBERMaGAFBERMaGAFBERMaGAFLkCW7duZdasWSQlJWEYBhs2bGhTZtWqVaSnp2O328nKymLbtm3dKiPSXT35Ob2WPssKSJErUFtbS2ZmJs8//7zp+nXr1rFkyRKWLVvGnj17mDp1Kjk5ORQVFXWpjMiV6KnP6TX3WXaJiE8ArvXr13stmzBhguvhhx/2WjZ8+HDX448/3qUyIr5yNT+n19pnWS1IkauksbGR/Px8srOzvZZnZ2ezffv2TpcRuZp89Tm9Fj/LCkiRq6S8vByn00lCQoLX8oSEBEpLSztdRuRq8tXn9Fr8LCsgRa6yS2+v5nK52izrTBmRq8lXn9Nr6bOsgBS5SmJjY7FarW1+PZeVlXl+ZXemjMjV5KvP6bX4WVZAilwlQUFBZGVlkZeX57U8Ly+PyZMnd7qMyNXkq8/pNflZ9usQIZE+rrq62rVnzx7Xnj17XIDr2Wefde3Zs8d19OhRl8vlcv3mN79xBQYGul588UXXvn37XEuWLHGFhIS4jhw54tlGZ8qIXIme+pxea59lBaTIFXj77bddQJvHvHnzPGX+53/+x5WWluYKCgpy3Xjjja4tW7a02U5nyoh0V09+Tq+lz7JudyUiImJC5yBFRERMKCBFRERMKCBFRERMKCBFRERMKCBFRERMKCBFRERMKCBFRERMKCBFRERMKCBFRERMKCBFRERMKCBFRERMKCBFRERMKCBFRERMKCBFRERMKCBFRERMKCBFRERMKCBFRERMKCBFRERMKCBFRERMKCBFRERMKCBFRERMKCBFRERMKCBFRERMKCBFRERMKCBFRERMKCBFRERMKCBFRERMKCBFRERMKCBFrgNr167FMAx27drl76qI9BkKSBERERMKSBERERMKSBERERMKSBERERMKSBERERMKSBERERMKSBERERMKSBERERMKSBERERMB/q6AiPSct956iyNHjrRZfuedd+JwOHq+QiK9mAJS5Dry3e9+13R5YWEhAwYM6NnKiPRyhsvlcvm7EiIiIr2NzkGKiIiYUECKiIiYUECKiIiYUECKiIiYUECKiIiYUECKiIiYuG6ug2xpaeHEiROEhYVhGIa/qyMiIn7icrmorq4mKSkJi6X9duJ1E5AnTpwgJSXF39UQEZFeori4mOTk5HbXXzcBGRYWBrjfkPDwcD/XRkRE/KWqqoqUlBRPLrTnugnIC92q4eHhCkgREbns6TYN0hERETGhgBQRETGhgBQRETFx3ZyD7Cyn00lTU5O/qyHXscDAQKxWq7+rIXLdU0Ce53K5KC0t5ezZs/6uigiRkZH069dP1+yK+JEC8rwL4RgfH4/D4dAXk/iFy+Wirq6OsrIyABITE/1cI5HrlwISd7fqhXCMiYnxd3XkOhccHAxAWVkZ8fHx6m4V8RMN0gHPOUeHw+Hnmoi4Xfgs6ny4iP8oIFtRt6r0FvosivhfnwvI2bNnExUVxb333uvvqoiIyDWszwXk4sWLeeWVV/xdjV5t2rRpLFmyxC/7drlcfP3rXyc6OhrDMCgoKPBLPfxp/vz53H333Z7n/vz3EJHu63ODdKZPn87mzZv9XY1ryubNm5k+fTpnzpwhMjLyirb1+uuvs3btWjZv3szAgQOJjY31TSX7sP/7v/8jMDDQ39UQkS7q0Rbk1q1bmTVrFklJSRiGwYYNG9qUWbVqFenp6djtdrKysti2bVtPVlGu0OHDh0lMTGTy5Mn069ePgIC2v8EaGxv9UDP/7T86OrrDuwb4+/0Q6Ss+Ol7JH/KPUd/k7JH99WhA1tbWkpmZyfPPP2+6ft26dSxZsoRly5axZ88epk6dSk5ODkVFRT1ZzT6ltraWBx54gNDQUBITE3nmmWfalHn11VcZN24cYWFh9OvXjy996Uue6+yOHDnC9OnTAYiKisIwDObPnw+4W4M333wzkZGRxMTEcNddd3H48OF26zJ//nweffRRioqKMAyDAQMGAO4uxkceeYTc3FxiY2O54447ANiyZQsTJkzAZrORmJjI448/TnNzs2d706ZN49FHH2XJkiVERUWRkJDAmjVrqK2t5cEHHyQsLIxBgwbxt7/9rcP3aMCAATz11FPMnz+fiIgIvva1r7F582YMw/CaGKKgoADDMDhy5AgAa9euJTIykk2bNjFixAhCQ0P53Oc+R0lJiec1TqeT3Nxcz3v02GOP4XK5vPZ/aRerWX1E5PLy9p2k6HQdu46c6ZH99WhA5uTk8NRTTzFnzhzT9c8++ywLFixg4cKFjBgxgpUrV5KSksLq1au7vK+Ghgaqqqq8Hl3hcrlobG7xy+PSL9iOfOc73+Htt99m/fr1vPHGG2zevJn8/HyvMo2Njfzwhz/kgw8+YMOGDRQWFnpCMCUlhT/84Q8AHDx4kJKSEp577jnAHb65ubns3LmTN998E4vFwuzZs2lpaTGty3PPPcfy5ctJTk6mpKSEnTt3eta9/PLLBAQE8M477/DCCy9w/Phx7rzzTsaPH88HH3zA6tWrefHFF3nqqae8tvnyyy8TGxvLjh07ePTRR/nGN77Bfffdx+TJk9m9ezczZ85k7ty51NXVdfg+/eQnPyEjI4P8/Hz+3//7f51+f+vq6vjpT3/Kr371K7Zu3UpRURHf/va3PeufeeYZXnrpJV588UX+8Y9/cPr0adavX3/Z7Xa3PiLXNZcLa0sjjc6eaUH2mnOQjY2N5Ofn8/jjj3stz87OZvv27V3e3ooVK3jyySe7XZ8mp4v/eftQt19/Jb45fTBBAZcf5l9TU8OLL77IK6+84mmVvfzyy23ukP3Vr37V8/fAgQP57//+byZMmEBNTQ2hoaFER0cDEB8f73UO8p577vHazosvvkh8fDz79u0jIyOjTX0iIiIICwvDarXSr18/r3WDBw/mxz/+sef5smXLSElJ4fnnn8cwDIYPH86JEyf47ne/yxNPPIHF4v7tlpmZyfe+9z0Ali5dytNPP01sbKyn1fXEE0+wevVqPvzwQyZOnNjue3Xbbbd5BduxY8faLdtaU1MTP//5zxk0aBAAjzzyCMuXL/esX7lyJUuXLvW8Vz//+c/ZtGnTZbd7aX1E5PKGlucRfe4IzQlfBRKu+v56zSjW8vJynE4nCQneB52QkEBpaann+cyZM7nvvvvYuHEjycnJXq2U1pYuXUplZaXnUVxcfFXr7w+HDx+msbGRSZMmeZZFR0czbNgwr3J79uzhC1/4AmlpaYSFhTFt2jSAy3ZdHz58mC996UsMHDiQ8PBw0tPTO/U6M+PGjfN6vn//fiZNmuR1vd+UKVOoqanxCq/Ro0d7/rZarcTExDBq1CjPsguflwtdxp3df2c5HA5POIJ76rcL+6qsrKSkpMTr/Q8ICOjUvrpbH5HrWfS5IwBElOd3XNBHek0L8oJLL5B2uVxeyzrz6xzAZrNhs9m6XY9Aq8E3pw/u9uuvRKC1cxeJd6Yrtra2luzsbLKzs3n11VeJi4ujqKiImTNnXnZwyKxZs0hJSeEXv/gFSUlJtLS0kJGR0a1BJSEhIW3qbvZvDd6fgUtHfxqG4bXsQtn2un3b2/+FFmrr99Bs1hqz/XelC7yz9RGRzrPXlly+kA/0mhZkbGwsVqvVq7UI7pbBpa3KnmAYBkEBFr88OjuLyuDBgwkMDOS9997zLDtz5gyffPKJ5/mBAwcoLy/n6aefZurUqQwfPrxNaysoKAhwDzi5oKKigv379/O9732P22+/nREjRnDmjO9OjI8cOZLt27d7hc327dsJCwujf//+PttPe+Li4gC8Btx09ZrNiIgIEhMTvd7/5ubmNueARaRv6jUBGRQURFZWFnl5eV7L8/LymDx5sp9q1buFhoayYMECvvOd7/Dmm2/y0UcfMX/+fE/rCCA1NZWgoCB+9rOf8dlnn/GnP/2JH/7wh17bSUtLwzAM/vKXv3Dq1ClqamqIiooiJiaGNWvWcOjQId566y1yc3N9VvdFixZRXFzMo48+yoEDB/jjH//I97//fXJzc73qf7UMHjyYlJQUfvCDH/DJJ5/w17/+1XQE8OX867/+K08//TTr16/nwIEDLFq0SLdME7lG9GhA1tTUUFBQ4PmlXlhYSEFBgeecVm5uLv/7v//LSy+9xP79+/nWt75FUVERDz/8cE9Ws0/5yU9+wi233MLnP/95ZsyYwc0330xWVpZnfVxcHGvXruV3v/sdI0eO5Omnn+anP/2p1zb69+/Pk08+yeOPP05CQgKPPPIIFouF3/zmN+Tn55ORkcG3vvUtfvKTn/is3v3792fjxo3s2LGDzMxMHn74YRYsWOAZkHO1BQYG8utf/5oDBw6QmZnJf/7nf7YZQdsZ//Zv/8YDDzzA/PnzmTRpEmFhYcyePfsq1FhEeprh8sUJlU66MGPLpebNm8fatWsB90QBP/7xjykpKSEjI4P/+q//4pZbbrnifVdVVREREUFlZSXh4eFe6+rr6yksLPRMUCDib/pMirT17ovukd8DkpNInNn9Hq2O8qC1Hh2kM23atMsOcFi0aBGLFi3qoRqJiEhfEWoLoKahmUBrz3R+9ppzkCIiIr2JAlJERMSEAlJERMSEAlJERMSEAlJERMSEAlJERMSEAlJERMSEAlJERMSEAvIaNn/+fO6+++6rvp8f/OAHjBkz5qrvpz2GYbBhw4arug9/H6OI9DwF5DXsueee80zh19v0RKj50re//W3efPNNf1dDRHpQr7sfpPhORESEv6twzQgNDSU0NNTf1RCRHqQWZB/3+9//nlGjRhEcHExMTAwzZsygtrYWaNvFOm3aNB599FGWLFlCVFQUCQkJrFmzhtraWh588EHCwsIYNGgQf/vb3zyvWbt2LZGRkV773LBhQ4f3rNy5cyd33HEHsbGxREREcOutt7J7927P+gEDBgAwe/ZsDMPwPAf485//TFZWFna7nYEDB/Lkk0/S3NzsWf/pp59yyy23YLfbGTlyZJvbo5mZNm0aixcv5rHHHiM6Opp+/frxgx/8wKtMUVERX/jCFwgNDSU8PJwvfvGLnDx50rP+0i7WzZs3M2HCBEJCQoiMjGTKlCkcPXq008chIr2fArI9Lhc0N/rn0ckbrJSUlPAv//IvfPWrX2X//v1s3ryZOXPmdDgh/Msvv0xsbCw7duzg0Ucf5Rvf+Ab33XcfkydPZvfu3cycOZO5c+dSV1fX7beuurqaefPmsW3bNt577z2GDBnCnXfeSXV1NeAOUIBf/vKXlJSUeJ5v2rSJr3zlKyxevJh9+/bxwgsvsHbtWn70ox8B0NLSwpw5c7Barbz33nv8/Oc/57vf/W6n6vTyyy8TEhLC+++/z49//GOWL1/uCVeXy8Xdd9/N6dOn2bJlC3l5eRw+fJj777/fdFvNzc3cfffd3HrrrXz44Ye8++67fP3rX/f8aLjccYhI36Au1vY4m2Bb12+g6xNT/w0Cgi5brKSkhObmZubMmUNaWhoAo0aN6vA1mZmZnnsuLl26lKeffprY2Fi+9rWvAfDEE0+wevVqPvzwQyZOnNit6t92221ez1944QWioqLYsmULd911F3FxcQBERkbSr18/T7kf/ehHPP7448ybNw+AgQMH8sMf/pDHHnuM73//+/z9739n//79HDlyhOTkZAD+4z/+g5ycnMvWafTo0Xz/+98HYMiQITz//PO8+eab3HHHHfz973/nww8/pLCwkJSUFAB+9atfccMNN7Bz507Gjx/vta2qqioqKyu56667GDRoEAAjRozo9HGISN+ggOzDMjMzuf322xk1ahQzZ84kOzube++9l6ioqHZfM3r0aM/fVquVmJgYr1BNSEgAoKysrNv1Kisr44knnuCtt97i5MmTOJ1O6urqPDfGbk9+fj47d+70amk5nU7q6+upq6tj//79pKamesIRYNKkSZ2qU+vjBkhMTPQc4/79+0lJSfGEI8DIkSOJjIxk//79bQIyOjqa+fPnM3PmTO644w5mzJjBF7/4RRITEzt1HA6Ho1N1FhH/UkC2xxrobsn5a9+dKWa1kpeXx/bt23njjTf42c9+xrJly3j//fdJT083fU1goPe2DcPwWnahm7ClpQUAi8XSpsu2qampw3rNnz+fU6dOsXLlStLS0rDZbEyaNInGxsYOX9fS0sKTTz7JnDlz2qyz2+2mXccdnQttzey4Lxyjy+Uy3U57y8HdPbx48WJef/111q1bx/e+9z3y8vKYOHHiZY9DRPoGBWR7DKNT3Zz+ZhgGU6ZMYcqUKTzxxBOkpaWxfv16cnO7f7ft1uLi4qiurqa2tpaQkBAACgoKOnzNtm3bWLVqFXfeeScAxcXFlJeXe5UJDAzE6XR6Lbvxxhs5ePAggwcPNt3uyJEjKSoq4sSJEyQlJQHw7rvvduewTLdbXFzsaUXu27ePyspKr67TS40dO5axY8eydOlSJk2axGuvvcbEiRMvexwi0jcoIPuw999/nzfffJPs7Gzi4+N5//33OXXqVIdf6l1100034XA4+Pd//3ceffRRduzYcdlrKwcPHsyvfvUrxo0bR1VVFd/5zncIDg72KjNgwADefPNNpkyZgs1mIyoqiieeeIK77rqLlJQU7rvvPiwWCx9++CF79+7lqaeeYsaMGQwbNowHHniAZ555hqqqKpYtW3bFxzhjxgxGjx7Nl7/8ZVauXElzczOLFi3i1ltvZdy4cW3KFxYWsmbNGj7/+c+TlJTEwYMH+eSTT3jggQcALnscItI3aBRrHxYeHs7WrVu58847GTp0KN/73vd45plnOjVopbOio6N59dVX2bhxI6NGjeLXv/51m0skLvXSSy9x5swZxo4dy9y5c1m8eDHx8fFeZZ555hny8vJISUlh7NixAMycOZO//OUv5OXlMX78eCZOnMizzz7rGYBksVhYv349DQ0NTJgwgYULF/pkZOiFSQuioqK45ZZbmDFjBgMHDmTdunWm5R0OBwcOHOCee+5h6NChfP3rX+eRRx7hoYce6tRxiEjfYLg6uibgGlJVVUVERASVlZWEh4d7rauvr6ewsJD09HSdI5JeQZ9Jkbb2vvo4NQ3NDElLJnbGkm5vp6M8aE0tSBERERMKSBERERMKSBERERMKSBERERMKSBERERMKyFYuzKwi4m/6LIr4nyYKAIKCgrBYLJw4cYK4uDiCgoI6PYWZiC+5XC4aGxs5deoUFouFoKDeP5uTyLVKAYn7AvT09HRKSko4ceKEv6sjgsPhIDU1FYtFnTwi/qKAPC8oKIjU1FSam5vbzBEq0pOsVisBAQHqxRBpV8/8t6GAbOXCnS0uvfODiIhcf9R/IyIiYkIBKSIiYkIBKSIiYkIBKSIiYqLPBGR1dTXjx49nzJgxjBo1il/84hf+rpKIiFzD+swoVofDwZYtW3A4HNTV1ZGRkcGcOXOIiYnxd9VEROQa1GdakFarFYfDAbhvJut0OrlO7vUsIiJ+4LOA3Lp1K7NmzSIpKQnDMNiwYUObMqtWrfLcIT0rK4tt27Z1aR9nz54lMzOT5ORkHnvsMWJjY31UexEREW8+C8ja2loyMzN5/vnnTdevW7eOJUuWsGzZMvbs2cPUqVPJycmhqKjIUyYrK4uMjIw2jwvTv0VGRvLBBx9QWFjIa6+9xsmTJ31VfRERES8+OweZk5NDTk5Ou+ufffZZFixYwMKFCwFYuXIlmzZtYvXq1axYsQKA/Pz8Tu0rISGB0aNHs3XrVu677z7TMg0NDTQ0NHieV1VVdfZQREREeuYcZGNjI/n5+WRnZ3stz87OZvv27Z3axsmTJz0hV1VVxdatWxk2bFi75VesWEFERITnkZKS0v0DEBGR606PBGR5eTlOp5OEhASv5QkJCZSWlnZqG8eOHeOWW24hMzOTm2++mUceeYTRo0e3W37p0qVUVlZ6HsXFxVd0DCIicn3p0cs8Lr07gcvl6vQdC7KysigoKOj0vmw2GzabrSvVExER8eiRFmRsbCxWq7VNa7GsrKxNq1JERKQ36JGADAoKIisri7y8PK/leXl5TJ48uSeqICIi0iU+62Ktqanh0KFDnueFhYUUFBQQHR1Namoqubm5zJ07l3HjxjFp0iTWrFlDUVERDz/8sK+qICIi4jM+C8hdu3Yxffp0z/Pc3FwA5s2bx9q1a7n//vupqKhg+fLllJSUkJGRwcaNG0lLS/NVFURERHzGZwE5bdq0y079tmjRIhYtWuSrXYqIiFw1fWYuVhERkZ6kgBQRETGhgBQRETGhgBQRETGhgBQRETGhgBQRETGhgBQRETGhgBQRETGhgBQRETGhgBQRETGhgBQRETGhgBQRETGhgBQRETGhgBQRETGhgBQRETGhgBQRkb7FMHpkNwpIEREREwpIEREREwpIERHpY9TFKiIi4jcKSBERERMKSBERERMKSBERERMKSBERERMKSBERERMKSBERERMKSBERERMKSBERERMKSBERERMKSBERERMKSBERERMKSBERERMKSBERERMKSBERERN9JiAPHjzImDFjPI/g4GA2bNjg72qJiMg1KsDfFeisYcOGUVBQAEBNTQ0DBgzgjjvu8G+lRETkmtVnWpCt/elPf+L2228nJCTE31UREZFrlM8CcuvWrcyaNYukpCQMwzDt/ly1ahXp6enY7XaysrLYtm1bt/b129/+lvvvv/8KaywiItI+nwVkbW0tmZmZPP/886br161bx5IlS1i2bBl79uxh6tSp5OTkUFRU5CmTlZVFRkZGm8eJEyc8ZaqqqnjnnXe48847fVV1ERGRNnx2DjInJ4ecnJx21z/77LMsWLCAhQsXArBy5Uo2bdrE6tWrWbFiBQD5+fmX3c8f//hHZs6cid1u77BcQ0MDDQ0NnudVVVWdOQwRERGgh85BNjY2kp+fT3Z2ttfy7Oxstm/f3qVtdbZ7dcWKFURERHgeKSkpXdqPiIhc33okIMvLy3E6nSQkJHgtT0hIoLS0tNPbqaysZMeOHcycOfOyZZcuXUplZaXnUVxc3OV6i4jI9atHL/MwDMPrucvlarOsIxEREZw8ebJTZW02GzabrUv1ExERuaBHWpCxsbFYrdY2rcWysrI2rUoREZHeoEcCMigoiKysLPLy8ryW5+XlMXny5J6ogoiISJf4rIu1pqaGQ4cOeZ4XFhZSUFBAdHQ0qamp5ObmMnfuXMaNG8ekSZNYs2YNRUVFPPzww76qgoiIiM/4LCB37drF9OnTPc9zc3MBmDdvHmvXruX++++noqKC5cuXU1JSQkZGBhs3biQtLc1XVRAREfEZnwXktGnTcLlcHZZZtGgRixYt8tUuRURErpo+OReriIjI1aaAFBGRvqULlwdeCQWkiIiICQWkiIiICQWkiIiICQWkiIiICQWkiIiICQWkiIiICQWkiIiICQWkiIiICQWkiIiICQWkiIiICQWkiIiICQWkiIiICQWkiIiICQWkiIiICQWkiIiICQWkiIiICQWkiIiICQWkiIiICQWkiIiICQWkiIiICQWkiIiICQWkiIiICQWkiIiICQWkiIiICQWkiIiICQWkiIiICQWkiIiICQWkiIiICQWkiIiICQWkiIiICQWkiIiICQWkiIiIiV4ZkLNnzyYqKop77723S+tERER8pVcG5OLFi3nllVe6vE5ERMRXemVATp8+nbCwsC6vExER8ZUuB+TWrVuZNWsWSUlJGIbBhg0b2pRZtWoV6enp2O12srKy2LZtmy/qKiIi0mO6HJC1tbVkZmby/PPPm65ft24dS5YsYdmyZezZs4epU6eSk5NDUVGRp0xWVhYZGRltHidOnOj+kYiIiPhQQFdfkJOTQ05OTrvrn332WRYsWMDChQsBWLlyJZs2bWL16tWsWLECgPz8/G5Wt/MaGhpoaGjwPK+qqrrq+xQRkWuHT89BNjY2kp+fT3Z2ttfy7Oxstm/f7stdXdaKFSuIiIjwPFJSUnp0/yIi0rf5NCDLy8txOp0kJCR4LU9ISKC0tLTT25k5cyb33XcfGzduJDk5mZ07d3ZqXWtLly6lsrLS8yguLu7eQYmISK/iMowe2U+Xu1g7w7ik8i6Xq82yjmzatKlb61qz2WzYbLZO71NERKQ1n7YgY2NjsVqtbVqLZWVlbVqVIiIivZlPAzIoKIisrCzy8vK8lufl5TF58mRf7kpEROSq6nIXa01NDYcOHfI8LywspKCggOjoaFJTU8nNzWXu3LmMGzeOSZMmsWbNGoqKinj44Yd9WnEREZGrqcsBuWvXLqZPn+55npubC8C8efNYu3Yt999/PxUVFSxfvpySkhIyMjLYuHEjaWlpvqu1iIjIVdblgJw2bRoul6vDMosWLWLRokXdrpSIiIi/9cq5WEVERPxNASkiImJCASkiImJCASkiImJCASkiImJCASkiImJCASkiImJCASkiImJCASkiImJCASkiImJCASkiImJCASkiImJCASkiImJCASkiImJCASkiImJCASkiImJCASkiImJCASkiImJCASkiImJCASkiImJCASkiImJCASkiImJCASkiImJCASkiIn2M0SN7UUCKiIiYUECKiIiYUECKiIiYUECKiIiYUECKiIiYUECKiIiYUECKiIiYUECKiIiYUECKiIiYUECKiIiY6JUBOXv2bKKiorj33nvbrAsICGDMmDGMGTOGhQsX+qF2IiJyPQjwdwXMLF68mK9+9au8/PLLbdZFRkZSUFDQ85USEZHrSq9sQU6fPp2wsDB/V0NERK5jXQ7IrVu3MmvWLJKSkjAMgw0bNrQps2rVKtLT07Hb7WRlZbFt2zZf1BWAqqoqsrKyuPnmm9myZYvPtisiItJal7tYa2tryczM5MEHH+See+5ps37dunUsWbKEVatWMWXKFF544QVycnLYt28fqampAGRlZdHQ0NDmtW+88QZJSUkd7v/IkSMkJSXx0Ucf8U//9E/s3buX8PDwrh6GiIhIh7ockDk5OeTk5LS7/tlnn2XBggWeATQrV65k06ZNrF69mhUrVgCQn5/fzeriCdCMjAxGjhzJJ598wrhx49qUa2ho8Arhqqqqbu9TRESuPz49B9nY2Eh+fj7Z2dley7Ozs9m+ffsVb//MmTOe0Dt27Bj79u1j4MCBpmVXrFhBRESE55GSknLF+xcRkeuHT0exlpeX43Q6SUhI8FqekJBAaWlpp7czc+ZMdu/eTW1tLcnJyaxfv57x48ezf/9+HnroISwWC4Zh8NxzzxEdHW26jaVLl5Kbm+t5XlVVpZAUEZFOuyqXeRiG4fXc5XK1WdaRTZs2mS6fPHkye/fu7dQ2bDYbNput0/sUERFpzaddrLGxsVit1jatxbKysjatShERkd7MpwEZFBREVlYWeXl5Xsvz8vKYPHmyL3clIiJyVXW5i7WmpoZDhw55nhcWFlJQUEB0dDSpqank5uYyd+5cxo0bx6RJk1izZg1FRUU8/PDDPq24iIjI1dTlgNy1axfTp0/3PL8wEGbevHmsXbuW+++/n4qKCpYvX05JSQkZGRls3LiRtLQ039VaRETkKutyQE6bNg2Xy9VhmUWLFrFo0aJuV0pERMTfeuVcrCIiIv6mgBQRETGhgBQRETGhgBQRETGhgBQRETGhgBQRETGhgBQRETGhgBQRETGhgBQRETGhgBQRETGhgBQRkT6m8/cXvhIKSBERERMKSBERERMKSBERERMKSBERERMKSBERERMKSBERERMKSBER6VsMXeYhIiLiNwpIEREREwpIEREREwpIEREREwpIEREREwpIEREREwpIEREREwpIEREREwpIEREREwpIEREREwpIEREREwpIEREREwpIEREREwpIEREREwpIEREREwpIERERE70yIGfPnk1UVBT33ntvm3U//elPueGGG8jIyODVV1/1Q+1EROR60CsDcvHixbzyyittlu/du5fXXnuN/Px8du3axerVqzl79mzPV1BERK55vTIgp0+fTlhYWJvl+/fvZ/Lkydjtdux2O2PGjOH111/3Qw1FRORa1+WA3Lp1K7NmzSIpKQnDMNiwYUObMqtWrSI9PR273U5WVhbbtm3zRV3JyMjg7bff5uzZs5w9e5a33nqL48eP+2TbIiIirQV09QW1tbVkZmby4IMPcs8997RZv27dOpYsWcKqVauYMmUKL7zwAjk5Oezbt4/U1FQAsrKyaGhoaPPaN954g6SkpHb3PXLkSBYvXsxtt91GREQE48ePJyCgy4cgIiJyWV1Ol5ycHHJyctpd/+yzz7JgwQIWLlwIwMqVK9m0aROrV69mxYoVAOTn53ezuvDQQw/x0EMPAbBw4UIGDx5sWq6hocErhKuqqrq9TxERuf749BxkY2Mj+fn5ZGdney3Pzs5m+/btPtlHWVkZAAcPHmTHjh3MnDnTtNyKFSuIiIjwPFJSUnyyfxERuT74tH+yvLwcp9NJQkKC1/KEhARKS0s7vZ2ZM2eye/duamtrSU5OZv369YwfPx6Au+++m7NnzxISEsIvf/nLdrtYly5dSm5urud5VVWVQlJERDrtqpzAMwzD67nL5WqzrCObNm1qd11nW6I2mw2bzdbpfYqIiLTm0y7W2NhYrFZrm9ZiWVlZm1aliIhIb+bTgAwKCiIrK4u8vDyv5Xl5eUyePNmXuxIRketW53skr0SXu1hramo4dOiQ53lhYSEFBQVER0eTmppKbm4uc+fOZdy4cUyaNIk1a9ZQVFTEww8/7NOKi4iIXE1dDshdu3Yxffp0z/MLA2HmzZvH2rVruf/++6moqGD58uWUlJSQkZHBxo0bSUtL812tRURErrIuB+S0adNwuVwdllm0aBGLFi3qdqVERET8rVfOxSoiIuJvCkgRERETCsguOnXyOPs+3Nl+N3OLs2crJCIiV4Vm+u6iQ3/5LwAK7Q4GDr3Be+WRd3B9tgXjxrkQqVl7RET6MrUgu6n02GGaj7wLH2+AlhYA9v7jz7xXeJpTe/7s38qJiMgVUwuymxqLdrPv+DlGJ0dSWXaUkn63UdPQDMCHxWcYfSgfwxZKbMowP9dURES6QwHZFa3OO9qcNdQ64WhFLScqK+Czlz3rHE1nOLTl1wBE3/1NLCHRYI/o8eqKiEj3qYu1K0wG4JyorO/wJce3vETppmdpaen42lEREeldFJBX2bEz5ygsr+Xnf99LfZNGuIqI9BUKyC7pfitwbPErHH//Dz6si4j0Ri6Xi7/tLSH/6Gl/V0WukM5BdsGVdpOWHdzBJ9ZhGGEJfC6jn49qJSK9yZGKOg6UVnOgtJqstGh/V0eugFqQXdDovPIu0sh9v+LQsVJe33scKg5DzSkf1ExEeosmZ4u/qyA+ohakH2QdfxWOw55AC/VNLRi3PsbEwfH+rpZI31JbAYVbIG0KhOmG7OJ7akF2gXEF5yDN1De5f2m6tvyYut2/8Uw4ICKd8MGv4dRB2P2Kv2vizdXC0FNv0L9yt79rIldIAdkFFuPq3cX6gz27qMv7ERTvdF9vebYI5+Et1Oz9q9f1lyLiVl9zlkOnajhbU8dvdhRxsLTa31UCIPDsZ0SfO0JK5S7O1jX6uzpyBdTF2iVXN6g+OFaJcWwdFdEHSa7ZS12j+5xncvgIUtIGXtV9i/Q1+0urqG9q4VR1AyWB5yiprGdYvzB/Vwujpcnz99p/HGZJ9gg/1kauhFqQXXD12o8XuYDo0wWecAQoenMNruIdPbB3kb7jwikKgBtP/H8kVH/sx9q0dvGH9KjS//NjPeRKKSC7IMDSExHZlsXVzHtv/JbVG3fw8dFSGqpOUXryBC6Xi7LjhZz7dItusyXXtSBnHeln3vF3NdxaDSVwNJ3xXz18qcUJJ/dBQ42/a9Kj1MXaRUmRDk6crfPLvseU/JaqErhw6v8PSV/ixhOvAZB19B+cHfFlgmP68+nxU9wQWoMtbjBY9BtIpCf949MyBvm7Er52dDsc+QfYw2HSN/1dmx6jb8+uCAymeuK/sTfhbgBG9ffvBOQXwhEg/+gZDr/+PL96+wMaNj/L7r+s4eSfn7xYuLaclqZGGptbOHH2nGfSA5fLpXliRXwopu5w917obILdv3KHUS/jLDtAeU0DjbVn/V2VHqUWZBfFh9motbmvWQy1BWALsNDQ3MKnMbcx6PQWLC7/dnWOPfEbz9+flddS+84f4PhuMKCsqoHdSf9MQ0A4WWlRTB0Sy6/eO0p9k5N5k9Kw1VeAIxqsgX48ApG+LbL+WPdeWPIBVB5zP9Im+7ZSV+BsbQP7PzoIQJDVIKsH9/3OviM47DbGDkzswb1epIDsovhwO3Nu7E+8KxKAEYnhFBSfpSJkMKcdA3Bhweas8Qoqfzp54F2v52NP/IbCqCkc+8hg87t7ibLFcTo4nbLNb2BUn+D42XOEZN7NgIyJ2AMsBBgu9/mHgCA/HYHIdcJ5cfRrS8leDIsVI2GkHyvk9uGml7jwk7nR6ePeppYWMAz3ozWXi9NF+7C8+0vqgVMxTxLQ0uDbfXeCArIb0mJCINAKQHCglczkCN4DXEYAY1IjKSjq3T3XrQcz2Jsria09ROvfvNUFG3jz0AEMVwtDXIUkRwazI3YOkbYWbhhxA4YBG/YcZ3B8GFlpUeBsBmuAO0gt1osbam6EE7shdqi7ZdpTWlp07lX6HGdLC5+WVhFiC+DUG78iwGIw+ks/cv+31UNcLheV55qICA7EMAyOnz1H4Jmudxm7XC5qGpoJs1/sjaqvr8dVWUxwSASU7YMzR6HqBE6Xi3xGMHzCDBznTlJRXcuJbf8f9c0XRzsd+v33fXJ8XaWA9AFHUAA0u/8Os10bb2l8zQEAzgJn65pwnFhLI/D23mQaA0JptCVy5sBeCu01nKyqJy4ujrSQZgwMrOlTYOCt8NlmOJ4Pn22Bad/13oHL5X5YLO3/iuyOM0fgw9/C4BnQ/8Yr355IDzlSXsuZuibO1Llbku72Ug+ND2iqh8pi8qsi2f5JCaNS45g+MpHiEyWmxQsKSzGsNjL7BdFcsA6LLYQKZwiR8SkE2B28diiQyjMVpJ15l+hzR6gJiiO0saN5p9/h48LOj0J29tCo/Wvj27wXSY12cFN6NEMbQvnk5LU3JPrC+ZULAVp6fqKQslOnKLvw+T/yZ3Z8GsfU0r/jCLJypq6J5NF1FJ+uo+RsHXdHH6Fk71s4m5tJy8mFPa9SFxBBUOY9OK12PjhyiiFJMXx8ooqY0CBGJIZ3rnKNtZzZ/jJNzhbiP9mkgJQ+pbm52WRp2x+NLS0uGp0t2AOtNDlbCLRaqDzXRLg9AMMwOFPbiD3Qij3Q3YtiGAYtLS6Onz3H3uOVTBkcS7i1keq9GwmwBbOvIYGk4j9jC7DQdLKG8QDHoaFxIgEF79N0yf7fffHbF/9u51gundak43DsusLCz+iJ+yEpIH3MMAwmD46FYhtQQ5UtkZOhIxhS8Za/q9ajJhx7iQag4Xw3ybH1T1AXFEtgYBQ7aj/1lDvx6//w/B3y6T5CggJwVjdwACgPHcFhezJDx8VT9tmH7A4ax21jhxNggT3FlcTaWxgY0gSWAIpPnaZi20ucO39T6sLyWm6a3r26Nza34MKFLcBqXuDSrmS55l24Q0egtW3Xff7RM0QEBzI4PtT0emRniwtL1TEMWxgER15c4XKBq4Wd+z4lzNJAXeOlUQRUFvNxTShvHzpLkuU0Y2wlvFnZnzojhCBnDZH1xdQHxdBEABaXk3OBUQyueIvI+mMUR4zH6mokqeoDmi12AlrqiQL2mcw5ctTkmHfnv9e5N+capoD0haQxjHJGUNvYTGzoxcEsQef/Y6qyeY/Aej9lAbeU/JKBcSHsL+kd80f2hJDGckIay9tdX9vgpLbh4hdMQs1+Emr2s+N19/No9lLw0cXyJ4GYxHDC7AEcK/S+OW2LC7btzGdoahJ7yyEmzM7AmBAiDm9w32Zs/AIqLRFYrVbOVVVQdmA7qSnphAa28D8fh5BU/QH33HIj1thBGK27fqtPwq6XIHUiDJoOTfU0G4EY5895Wk0mk6hvctJ4qpBwm0F9+ADs589f42yG/X+CmMGQOLpzb2LpXjhbBENzLnue9Vyjk+CgjoO8tLKez8prmDAgGqvFoKG55WL9gMq6Jk7XNZIeG+L9wqZ6aKpzn1t2ucy7xxtroaYMogaAYdDY3MLrH5cyJM7BiMSIi69pqAZLIBx9BxJugLDzbYPzAULTOQgKcZd3uaC5HgKDTY+nrPIcYQHNBJ8rBWsQRKRcfJ+aG9zLLqlrs7OFgNbB53JBUx1nmgJ553A58aFBvP/JCWLqDpNxQwajBqdjWKw0NDVSduoUx979GzvCMzntLCC48rM2ddrxy+8Qbg9geGI4TaO/zMvvn2BIxZsEN531lGlvOoGP/vYC1fXNnpGjJ4GMdspeKqVyp+fvgJb6Tr5KWjNcrutjJuyqqioiIiKorKwkPLyTXXYdeX8N1FXA0JmQNLbtF8TbKzjX5OQfp4L5KH4WMbWHPK3I+M//gEEf/QyAgnNx7GgZzqiTG668TtJlx8JvJLnq4l0XokOCOF3r7jcOsVl5J/oePpdYR130cCLCwkgseI7jZ85xrsnJoJRELA3VbDnWgq25ikarA1tzLcOSY2DiN3EaARyvbKB06y+JqD9OYoSdAmc6zWHJfGHmHViO7cD62du0uFxY+t1AacKtHKl0Unr0ADcOGwjVJTQW/IEBsQ4CJizAdfhtqk58SojNijEsB2d9NZbYIRhh/bBWHMQVPYhNB04TGRzAp/sKaCCQqQEfE99yCiPIwZuhdxEWHkV6UCXRZe8ReuM9rPrHCXC5iA+1cqaymqaAEG5Mi2J0UjiNLS5ee7+I+JoD3GUrwDZ6Nq6wRLYfbyK+4HkibRb6RdgJsBpU97+FTwuPUm2LI23EOE6fa2Hk4RcpOlXJx5HTufWGVA4f/Ajn0YudcsMzbiSkupCTVfVEOgI5U9vEmbpGmp0tDB13Gx9/8imuM0WkRTs4e66JoNh00q3lNDpbKKuq50Rl+1/66bEhxIfZaG5xURQ7lVP5f2JEvzD2X5jQfMBUzpw5RUtTE0HOWg5H30JK5S5i6toGnPROkxb8tNuv7WweKCC7q7kRzp2G0ATzX89vr3D/f2QKzswvs/avmxlZ9lcABn3xKeJ3/RcArpFf4N3qeKILVnOmsvLK6yW9SkNAKLZm35yLtgdYvEb2dUeFY+BlQ6AhIAxb8/XTsyF9U08EpMbCd1dAkLsr6HIjL10urBaD+8aleC+/8QEYcgdG/AgmD44ldsZiPo6fRXnIYMA92Ef6Pl+FI3DF4Qh0qoWkcBRx0znIqyXQ7j5PE+OelTHcfslbHdHf/bggwE61PZEmazCxtYdwXObckYiIXF0KyKtl3AKoLIa44e7nrXqyDZOh2xHB7gtqmyx2ACIdgcSH2QiyWjh29tzVr6+ISB/RbLH1yH7UxXq12MPdI/IuXA4Q6PDM3Rod0nbatkCrhVmZiTitdk6k34ORNZ9B9zxJSuY04sNs9Avv+ANxY2rkVTgIEZHex+DKTzd0hlqQPSUsgYypn8cVFI6lnftKDo4PY95kG2H2wXBh2Png2xl0/mbJpVUX5yK8dLBFu9fsiYhca3poaGmva0EWFxczbdo0Ro4cyejRo/nd737nWVddXc348eMZM2YMo0aN4he/+IUfa9p1RtpkLIkdX8UUHRLU9mLkjHu8nlbZEvk0dgYH4mYC7ruKXGp4v7Arq6yISC913bYgAwICWLlyJWPGjKGsrIwbb7yRO++8k5CQEBwOB1u2bMHhcFBXV0dGRgZz5swhJibG39W+uuKGwvSl8Jl7iqeSsFEA3DAqi0jLCFITE6ClDj77oeclAVYfzGsqItILGa6eCche14JMTExkzJgxAMTHxxMdHc3p0+5ZUqxWKw6H+/KH+vp6nE4n18llnAAcDx/LWXsy1SFpfOmmVMYPiGJoWjL2oECwR1AbFGv6OkeQlRuSLl7rszvpS4xJiTQtawvodR8JEREvPfU11eXdbN26lVmzZpGUlIRhGGzYsKFNmVWrVpGeno7dbicrK4tt27Z1q3K7du2ipaWFlJSL1xCePXuWzMxMkpOTeeyxx4iNNQ+Fa1Fx5HgOxN+Jwx5EQrjdewo04OyQe72enwhzT1+WmRxJuD2QhPMDfRoDQglOyWx3P0cjJ/q45iIivtNT/WNdDsja2loyMzN5/vnnTdevW7eOJUuWsGzZMvbs2cPUqVPJycmhqKjIUyYrK4uMjIw2jxMnTnjKVFRU8MADD7BmzZr/v707D46ruhc8/r1L77u6W62ltUu2LMmyLMlC3vGCwYDZ5pnAS4z9gEwIMBMeM5UKk5lKVf7hnykqfySkJjW8yrxXlQpVMxUqmeKR8jzycCo8wBgbO9gGvNvYlizZ1m6tPX/cVqtbfSW1dlv+fapcZd0+d2sd3d/9nXvuOSnb9/v9fP7555w9e5bf/OY3tLS0TPcU7liPrc4n7LGxa5X57Nojmo0BzRgz06ZrxJTUjjsOi8ZVd7Xxg8Vh+q6lRVNpca+Y2wMXQog70LSfQe7cuZOdO3dO+Pkbb7zBc889x/PPPw/Az372M/74xz/yy1/+ktdfN4ZfO3To0KT76O/v5/HHH+e1115j3bp1pmUikQi1tbUcOHCA3bt3m26jv3+s12dnZ+eU53a7Kwm50geNnoBVU9lcGcF52WcssDhoW/4o5y6N/srN78GMDrbGZ0GXlbaeQZQpuoydC6yj+MaHGR2XEELMVp9tYfqdzGlL7sDAAIcOHWLHjh0py3fs2MGHH2Z2AY3FYuzbt4+tW7eyZ8+elM9aWloSga6zs5MDBw6wfPly0+28/vrr+Hy+xL/kZtqlauOyEDEU8v3GTAfh5etwWeMBcfV3GHQlZ56xRIjss/jptWQBEHTbGFF1WnM20xLZwJBmn3K/Vz01tNS9lLa8wx6lyxaZzSkJIUSam86SBdnPnAbItrY2hoeHiURSL4qRSISrV69mtI2//OUvvP3227zzzjvU1dVRV1fHsWPHALh06RKbNm1i1apVbNiwgZdffpnaWvNpgl577TU6OjoS/y5evDi7k7sD5PocbHj0OQojQah8KHVKINu41z40W2Jqps9zdhNTjKoQ8dh4fHU+O+57kJtZddzSfRnte+eqQoLjBkD4KrSNLyKP8kn02WmfSzgnnz6Lf9rrCSGWvtHr1Xybl9c8xnceicViacsmsmHDBkZGzLvwNjQ0cOTIkYy2Y7PZsNkWZjii24keKID1PxgbRH3ti8YkrroN6B0rWNBEUfkZPrgRJMttMyaaw/jdFSc1454KbqHo5kdc9qzE23+VgpsHU5pcv/GuBoxnnsUhF+3xqaKuO4oZjg8H1VQSoKzfhd2icbq1e8pBtwsCDqIP/T1/2P8V91z8nwvWpVsIcWe45q9bkP3MaYAMhUJompaWLba2tqZllWIeJd+M2CfIAHUb7nv28hBw5lo3Z06bF+vXPXwVug+AblsOlz21PHLzn2jt6udEeCcd9ujYbpPWG+0sBLC2LAzfGE21pWt2cPrEYS4Nernka8A9cI2Ktn9J2WfyhL0zkcmUTkKIO5fNalmQ/cxpnmq1WmloaGD//v0py/fv3z9hZxux+EpCLqpyvdRGU4OpZ/wMJACKSmnYxeoCP2srC0BRKAoa76aO5DcklUtaR9Mh2gihCnxV26l/4j9zOriFft1Lu7MsUaw05KIoy0nQnT5WbSbKwkZQbnFXzWh9IcQdIsMWydmadgbZ3d3NqVOnEj+fPXuWI0eOkJWVRWFhIa+++ip79uyhsbGRtWvX8qtf/YoLFy7wwgsvzOmBi7mjKAp5fjt0pVaH5tIg3f1DlIRcfHzmOh19g0Z5FOwWjcocD6HcrMTg67HSrfDh/zP+P76XbMV9yTs0PQ6PXcdpHTuG5tIgX956gGWt/5zSrHswuo9yZw8rVtSQO9LC4T+8CRhD7tXf9zT1eXV89r/+b6L8ifBOVlx7j7kYwHFAc2Id7p26oBBi3tRF/Quyn2kHyE8//ZQtW7Ykfn711VcB2Lt3L7/+9a/51re+RXt7Oz/96U+5cuUKNTU1vPvuuxQVFc3dUYsFYbdoPFybB0DXrSH+7XQ7OT479BifK7qNsDPpOa+a3DQ6+zu8tWVB7inZwi/ez6eo7V8J93xNq2cFmtXOzg3VKIpCLFbCkGpDHzFe6bEVGlmsrioMjRgBscNRwJHc3YR6T3NL91De/q+m+/si8gjVLb+nJOTibFsP7c4ygr2pbc9ty54i78Q/zPrcAFpdy8nu+XJOtiXE3aQm3zt1oTkw7QB57733Tjm824svvsiLL74444MS82M2o/I1FWeR47WT67fDtYdgsA+cWSllrEmDrKdlkOM8UZ9PS2c/Nfle3n7vASqvvTf24T3fS/xXVRVQVM5kbeSaaznPPLAeRdVSOn0dizxGdesfGCwZu3Ebf6q3LH4u+Yzg6RjsIL/zMABDqh195BYAXdbslHWuucoJ9p6mOs/LF5c7ue4oJicchhPG5xd9ayjoODjpeQKcydpI6fX00aTOBDezxXeFL692JYK5EGJqmXb6nC0ZeFNkRFWN3q02XYPcWii8x7RMY1GAxqIAIbeRWZZlu023VxR00VSShV3XuOkoTP3Q7k8rH1N0Ou15WCwW9HGznfRbfHyW922G8tZkdC5D6tgzzi/jHZBa3ZWgqHwSfZbA/T/k0/xnuKX7qMh247Vb+CzvbxOdlUbn3tRsDvL8drxJz2ptukrIbWVF0zZKQi68dp3WSUYm8jbsprE4MOnx1uR7cVgm/lO95K3nbGADV93V9Oup3/dMxqwf1BxTFxJ3vRFlrN5f9DVMUnJuhQoXbqQvCZB3EbNpsRIC8Rdvtdn1DrNoKhZNpbksyH1VEe6vnrz3cvKNYCKHGvdax1S5ldumo2sqPsfYsfdajezW7F3KFnc1NxxFnMnaRJc9l9yH/wtnAhsBqCsJY7O7GNLsDKl2rPFRkQc0p3GwioJN12gqzuKx9bUU1aynuHzsD7a+MEDF4/8Vf+UWckpqqN6+J23/UX9SALK6UUyy7eQglfz5BX9TWtlLvgZaPFWcy1rP5zlP0mkbGxCiIMuZUnZ0S8llwHhOO+p4+KG0fbS4V6TN4p7plGpum55yE7GQTmdtntF6sz3eCaZ8vaNcdxRP+nlygBxRpn/d+Dx394w61JVvn/571TMlAfIusizipr4oYD6Wa/FGWHY/rHl+djvxGs8sbdE6avJ9GU/k/NfII8Z/LA6j12uGFEXh2Q0lfP/espTM8nrpY3zjreNE+EE2LQsnlu+ojjCi6nwZvt/IGoGAx0NdUQCrriayw8dW57NuRRRv07eh7mmIv5g8et3TVAXN4oDlO3Hds5fioJOK0WzZ6gSLHWp3Q8QY+7ZfN4LJJV8DuX47vdmruac0CxxG9lid58XnsGDTVXotAf4aeRQAu67ismnEMC5Yl711fFT47zmS+yQ3HEXkbd5Habab5Tke9qwtYkTVOR7ZlZgSzWnVU7LPwLYf8HVwa+L91VF9lqQs1qT5alB18Gl0L8dynhjbVm7phDPIjFoecVNVs5rSx/8bn0T/LrHcpqt47XpahlsQmDh7rcqd/nOna27zkbamUp3no7kka8JHBU3FWabLR422oMyE2RjJk5mPm4+jOWNz0DaXmp/r6HdjHT9/bYb6LIHECF4ALYEGzvvTW6YAToQfBMBuUReseRVuw/kgxfxRFIXNScEihaZDfv3sd7J6DwzdMoLENHTbcuht/iEuT/qFpTjk4nRrN36n+V2qMSJQ6h/NfavLORjIYkvUT9BtI9dn50pHH1W5Xv5yqo2e/uGxwgpsWZ7N5oqw8cyT5HFvR/+AvzLZ81hum+ub+MLudVg4krsbfbifQd2FtmEX26yusUDU+CxezULVx/+D09e6OWZrpF83gkFVnjeRQY4Gtec2lvDWn8/yZfh+6kIFPFqevu8uWw6bnWfxOSzk+R2cvtZDyG1l0Oqj3VWO79allPIDupvz/mYcdhsjSYPcOywafYPD9Ose7quKsP+4sTwacEBeHaeuLmPVlbFJzQuznAwMj+CyajitutFq4Y3gcLoYUY3fX77fQWE8sx2Jxfj1rU2suPIOADk+Oxdv9KWdT3WeF6/dQp/Fj2Pw5oTftZkYSqIX9EcF36X5YupE6zccRQT6zqetpygKKx75e86++zP6xw1uoY1LEU9kP8iK1ncTP+f47NzsHeScs4a8rqMZHeeKXA9tXf1kuW18ebUro3UAcn12rg5bABXnYPuE5T7Nf4bGb/4xZVmraznDqpXcrmMpy3utY2OdKiicDKf2EzgbWE+04zMA/E5LWovEeC3uFTgHr+Ppbxm3vBItNogWLCYQKaT75Ccpn7c7yxjxFTAYW5xmf8kgxdxS1WkFx+S7QdP3LoEdVRE2LQvzNw1R08/NeOwWtlZGCMbv5PP8DhqKslAUhW+tKaS5dOwCMHqxU+epXezppgJiis6gHh88ITk4AngiiQ5PRuAYC7wWk7tzr33sRsExwaAK1x3FBJuegqpHyPbYWV3gp6zpocS5dlvGMj+7rlIb9RGp2cSjD+0i1xcf1CHkoq7Az8p8H1W1jYkM7lRwC0ORVZBdnWhmy/Pbyd+8j/ySSkrWPkG2xz55k36cqijsXN+AriqUhV1oSd9LWmay+YecC6S+T/1xwbN8VPBdDkb3TbiPsexYMc2Ovw5uNR+6zOIgEM5jdWV52jvC43XaculNysJdVp0VuR5CuYXURn0sT2qO7rGGuKWnZsMWTcHvsFKe7Un73kazp4kEXFbOB9ZyMny/6efHIo/xccGzuD3pTeJngpu56DOe3Y8oOkdznuBQ3rcBUl6tGlZT303usQYT96QK0GML89fIoxzK+3aitQTiTflWJ9t3/S2nglsTy+sL/XxvcykoKpe9q+izZ7OhIr014uvQNrxlTYv2XFwySLHovruplOHh2IQj6NgtGg1Fk3dkmQ6fw8LasiCxWIyhkVhGF3JTGXYLTn63cyoWTeXJxijn1Bwq1ADq6AU9BrcsYxfph2tz6RscJuCaYFAFRYHs5dBvZCJ2iwYl6ymP95Yd1uwM2LJYFRjEbdfRV4w9K36sLp/hvgC6agQNt02nviQ78WCtzVVBZ2E2qCo1+V6813UKA06U4mWg10DHJTIWXkauz0FOcSCRKa8pDjASM4LGR2eMydJHbD5QNTps+YlVO205xOIBelhJ/R7Cbit9gyM4rRpfhndQ0PFpYn7U8UZUC82Na7h15STf3Owj2xMfoD/+uEFxBHD1trMix8OhvgiNzlbAeJZ86aaR7cYUjaM5f5OSnTqtutFic1zHZTWalT8J/ztu6R6sw700ql8xfOmz1INRNaxAbdTH0UsdAHQ4opyrepHi42+af4eRajoG80FRGNIcFHpiXL4Z75lty6HHGgZF4Zm1xXx9wcKN3sFx569zMLqPEUVNfJ/jJQd/gEEt6SY4XkW74xMT9Ol+bENGvTue/TBrigO4nQ72bVtF93u/J+iyoWkaJP1dKJD2OGZV1IdaFmR1YQCP3cLRgQe4v3ZhJ52QACkW3YwD1CytK5/BZNspCYhJgJyD5yMOi86KbC+cHMtqjhbvY3hg7HuqiGTWQQabB+r3gGYEEE1V+MG2Ck5f66bgQhR79zdpqygKieBI03dB1ce94zpmU0UI2sdlV47xNzMTfCfl26CgKV5irExi36u/w6mOo+R0/RW9cc/YwcWNZq85PiNbHfE8waqb/4JNV9E1BcUZQomG2H98OCV7SRZwWniqqQD1wlGcVp2K7KTv1RZ/plxxHwz24q9aw7Yb5+DKDcBoWhwNkOOPDYCSTSk9susK/HwwbHw3/bqXNduf5qN/MALkqchOGrdshS/egdYTuKw6DUUBDp039nXfyny+Pp5+/G2ucpSqR+Eb4xFA7eYn8J17LxEgv8jelTguTVXIXrmdGx//MwBXPDWJ7YzPECF1QPBh1can+c/g7b+MGhumX/fi93rpudFHxDs248/KfB+DrUZLyIXrvaAoKPHfp9Oq4/RMPTvQKKdV5554S09DUYC6gm1pTdvzTQKkEAss404GrhD0tEFWKcNdDmBwylWcVo3egWFctqSA5kttmlZVxQiwlzPoDGL3mfZsNmv6TQQIqwvWPAcH30orcjL8ANHBD4wfkjNwTwS6kp5PaRbwF7BrR4SBoW24vWYXVoWQ28rTTfHXhLp1OBjfdsEayG+kWB0bE3hrZTbvn2zlG28d+Z1HAKjM8cL458dWJ5SOvVOLww8Ne43/+6Jw8zzkrcZz5oO0I+rX3AS0eNAsXp/ymTru964oCuXZbs6397ClcjSDH/tOrJpKc0kWazaXo2sql21a6rPzJGuKs+gbHMZbXAEtHwHtoztJKZdVs41lRev4PwcO02OZvKPReX8zroE24wbhBAxpdq47SwFjII6VVdUMfzNgNIvHD6u+KID7VgRrR68RICeS9l2YlBn3nvVCB0eQAClERrwOC519g5Rnu6G/Gm51gDvHpORc/BHHL5KrnoKWLyCnltgnLZOvEre7sYBPzrbTVDI/E8puXh7m0o2+sWdqelLgSn6O504ddGHUTUeheZxfvQcO/Pe0xX7nxOPy9lqzUnP4pM5FlG83DgP4/r1lWDQVTVV4/2QrF/1NXHcUs7LlHfMNr/uPE7cE2L3Q/H3j/74oRYO/471bRk/lR+ryKLRnoQ12p66TXQmtJ003F3bbCLmtKKY3AEYQHe2dXZ3r45Nz17nsqU10/BntHJPy/M7iIOy2ca27P217AEGPg7LSMo5e6mBjRYgTVzpp6x5IK9evezic9zT3RpfBCSNDLcxyMjg8wr3Ls1GunkJXVWLjWlKsltSwEk3umezNhc4rEK40P9/kba16yrTMQpIAKUQGnllbRO/AsPGuZdUj014/+ZnS1OIXZ5sHCpuntZ8sl5UHaibvUZhgmX7Hh/rCAPWFSU2oFodxIVO1CZthRzmsGn0Dw/hdoxlp0sVwfJY6SZZ9LPIYwb6zXPLWU5b8DNYVNHpijzuv5GfbmqowPBJjeUkRza4JMqhMM3xflNztL/NIzwA+h8XIqi/4oLMntZwnNxEgH1+dz3tfXGV70jNfBQVc8d7lBc0TBlNt7QusLDyBQhkrww9y8ssTrCutSy/oL8KinZp0zsStldmsLw9ht2gMjcRo6zYyzjy/ncs3b1GW7eZ0a3faenl+B2vL4jdfJlP8xmIxKNsKXVdZuXkzuf58ioJjWTwrn4T2U2kBcrSJPdtrg+vxhRPNRLSAJEAKkQGLpuJzZNDp22l+0a2N+qcOkHl10PkNBMunf4AzUb4dBnshv3F228maYHb3YBm0nzZGXgL+bn0x3beG8Byc3WAUPbZsemxGhlqdN+4iusy8J+eofeuLuXTdyICVspenDOpTURQl9Z3Hqkfg6/1QkPQ+X3QNoEBWCcVuF9/bVDrWzL7uZRjqNzJTMDKsja9C21dwYmzAfQCcWbgr1jN6y9Rwz0bzgyreyPWWYY64/IlFa8a9t6koSuLGoTbq47MLN6jI9rBpWYiWjn6iAQcXrvfidaT+rsZni6acWbD2JdyKQto4WlZnoj7AWEAeHVu1ub6Oq20fGGM+3wYkQAoxFxr2wYV/g9J7Z76N5Tsn/Giq8Y9nxO6F1d+Z++2OWrkbhgdBN7I8m65hc88uII0Ke2w8UJMz7RfyvXYLVXnxi7496VWLWY4gleAIQO2TqctULWVoxpRn0DaP8S+ZPsuJ3jUdX0Uz/UcuJxaZvUIxymnVeWFTWeI1p8L49HXJE6ebitdJs5GgMs3Cn6iP0t49QMRrnLMnEMHz8H+a9nvU80XegxRiLnhzoeaJCTPIxehgMGPWpPt+ZRYBTVESwdHU+KBvS9qv0/yCvmlZCKuusqM6MqvRatKUbjGem05yk7Kg/PHZj2bQDA7EB7nI3Fy9AzydV5rAaJnJ8dlTbxpcwRmf91yTDFKIBRBwWliR68UxzWHERm2pzOb3Ry7TVDJ5z8M5oVmMjiiKagz8sFBWPQ3H/rex/+rHTIs0FGVRXxiY++HG7F6j5+3twu6Fdf9hxtnkvA3HlnxPk/SM8DvNRQyNjMy4ft+uJEAKsQAUReGBGrNer5kpC7t5cUtZxmPbzprDvwA7GZdBukLQPPXE6gs5FueispnPhJOp+6tz+OMXV9k4SfPqrBQ0GQNRhCoImwwRuRRIgBTiDrFgwVEsCVV5XsqyXXNab1JuaTQLLH9gzrZ9O5JnkEKIxTEfHY9ECrmpmh0JkEIIITJyt93TSIAUQgghTEiAFEIsrNGemcGyxT0OIaYgnXSEEAtr7UvQ32287ybuKPmB2+P9xIUiAVIIsbB02+xHixEL6vmNJbR3D1AUvD1GuFkoEiCFEEJMymO34LHP0XB8dxB5BimEEEKYkAAphBBCmJAAKYQQQpiQACmEEEKYkAAphBBCmJAAKYQQQpiQACmEEEKYkAAphBBCmJAAKYQQQpiQACmEEEKYkAAphBBCmJAAKYQQQpi4awYrj8Wnwu7s7FzkIxFCCLGYRuPAaFyYyF0TILu6ugAoKChY5CMRQghxO+jq6sLn8034uRKbKoQuESMjI1y+fBmPx4OiKIt9OKbWrFnDwYMHl8x+52K7M93GdNbLtGwm5SYr09nZSUFBARcvXsTr9WZ0bLe7xaqz87nvxaq3011H6u3MNTY28v7775OXl4eqTvyk8a7JIFVVJRqNLvZhTErTtEWpgPO137nY7ky3MZ31Mi2bSblMyni93iVzoVmsOjuf+16sejvddaTezpyu6xnFA+mkcxt56aWXltR+52K7M93GdNbLtGwm5Rbrd7hYFvN8l1q9ne46Um9nLtPzvWuaWIVYbJ2dnfh8Pjo6OpbMnbhY+u7meisZpBALxGaz8ZOf/ASbzbbYhyJExu7meisZpBBCCGFCMkghhBDChARIIYQQwoQESCGEEMKEBEghhBDChARIIWbhwIED7Nq1i7y8PBRF4Z133kkr8+abb1JSUoLdbqehoYE///nPMyojxEwtZD1dSnVZAqQQs9DT08OqVav4+c9/bvr522+/zSuvvMKPf/xjDh8+zMaNG9m5cycXLlyYVhkhZmOh6umSq8sxIcScAGK/+93vUpY1NTXFXnjhhZRllZWVsR/96EfTKiPEXJnPerrU6rJkkELMk4GBAQ4dOsSOHTtSlu/YsYMPP/ww4zJCzKe5qqdLsS5LgBRinrS1tTE8PEwkEklZHolEuHr1asZlhJhPc1VPl2JdlgApxDwbP71aLBZLW5ZJGSHm01zV06VUlyVACjFPQqEQmqal3T23trYm7rIzKSPEfJqreroU67IESCHmidVqpaGhgf3796cs379/P+vWrcu4jBDzaa7q6ZKsy4vaRUiIO1xXV1fs8OHDscOHD8eA2BtvvBE7fPhw7Pz587FYLBb77W9/G7NYLLG33nordvz48dgrr7wSc7lcsXPnziW2kUkZIWZjoerpUqvLEiCFmIU//elPMSDt3969exNlfvGLX8SKiopiVqs1Vl9fH/vggw/StpNJGSFmaiHr6VKqyzLdlRBCCGFCnkEKIYQQJiRACiGEECYkQAohhBAmJEAKIYQQJiRACiGEECYkQAohhBAmJEAKIYQQJiRACiGEECYkQAohhBAmJEAKIYQQJiRACiGEECYkQAohhBAm/j/KvnNqrmeazQAAAABJRU5ErkJggg==",
+            "text/plain": [
+              "<Figure size 500x1000 with 2 Axes>"
+            ]
+          },
+          "metadata": {},
+          "output_type": "display_data"
+        }
+      ],
+      "source": [
+        "from dot_pe import evidence_calibration\n",
+        "\n",
+        "# Resolve rundir to the latest run in the event directory\n",
+        "rundir = sorted(\n",
+        "    event_dir.glob(\"run_*/summary_results.json\"),\n",
+        "    key=lambda x: int(x.parent.stem.split(\"_\")[-1]),\n",
+        ")[-1].parent\n",
+        "# Create Gaussian noise event data with PSD from the event (by default uses wht_filter)\n",
+        "noise_data = evidence_calibration.create_noise_event_data(rundir, observing_run=\"O4\")\n",
+        "\n",
+        "event_data = data.EventData.from_npz(filename=rundir / (eventname + \".npz\"))\n",
+        "\n",
+        "\n",
+        "fig, axs = plt.subplots(ncols=1, nrows=2, figsize=(5, 10))\n",
+        "\n",
+        "for det_idx, det_name in enumerate(event_data.detector_names):\n",
+        "    axs[det_idx].loglog(\n",
+        "        event_data.frequencies[event_data.fslice],\n",
+        "        np.abs(event_data.strain[det_idx, event_data.fslice]),\n",
+        "        alpha=0.5,\n",
+        "        label=\"data from rundir\",\n",
+        "    )\n",
+        "    axs[det_idx].loglog(\n",
+        "        noise_data.frequencies[noise_data.fslice],\n",
+        "        np.abs(noise_data.strain[det_idx, noise_data.fslice]),\n",
+        "        alpha=0.5,\n",
+        "        label=\"simulated noise\",\n",
+        "    )\n",
+        "    axs[det_idx].set_title(det_name)\n",
+        "    axs[det_idx].legend()\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 23,
+      "metadata": {},
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "Slim evidence blocks: 100%|██████████| 32/32 [01:17<00:00,  2.42s/it]\n"
+          ]
+        }
+      ],
+      "source": [
+        "# Recompute ln_evidence using rundir setup but with noise instead of real data\n",
+        "ln_evidence, ln_evidence_discarded = evidence_calibration.compute_evidence_on_noise(\n",
+        "    rundir=rundir, event_data_noise=noise_data\n",
+        ")"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 25,
+      "metadata": {},
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "From rundir:\n",
+            "ln evidecen: 12.07979133605388\n",
+            "ln evidence discarded: 2.381006217706066\n",
+            "Using evidence_calibration code on noise:\n",
+            "ln evidecen: -20.171190311304724\n",
+            "ln evidence discarded: -inf\n"
+          ]
+        }
+      ],
+      "source": [
+        "print(\"From rundir:\")\n",
+        "summary_results = read_json(rundir / \"summary_results.json\")\n",
+        "print(\"ln evidence:\", summary_results[\"ln_evidence\"])\n",
+        "print(\"ln evidence discarded:\", summary_results[\"ln_evidence_discarded\"])\n",
+        "print(\"Using evidence_calibration code on noise:\")\n",
+        "print(\"ln evidence:\", ln_evidence)\n",
+        "print(\"ln evidence discarded:\", ln_evidence_discarded)\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Step 4: Validation on same data\n",
+        "\n",
+        "Run evidence calibration on the original event data (with signal, not noise). This should reproduce the rundir's ln_evidence from summary_results.json and validates that the slim evidence path matches the full inference."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "Slim evidence blocks: 100%|██████████| 16/16 [00:58<00:00,  3.69s/it]\n",
+            "Slim evidence blocks: 100%|██████████| 16/16 [00:56<00:00,  3.55s/it]\n"
+          ]
+        }
+      ],
+      "source": [
+        "rundir = \"../notebooks/03_run_inference/artifacts/run_multibank/run_1\"\n",
+        "\n",
+        "# Use original event npz (with signal, not noise) to validate we reproduce rundir's ln_evidence\n",
+        "ln_evidence, ln_evidence_discarded = evidence_calibration.compute_evidence_on_noise(\n",
+        "    rundir=rundir,\n",
+        "    event_data_noise=\"../notebooks/03_run_inference/artifacts/run_multibank/run_1/tutorial_inference_event.npz\",\n",
+        ")"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "From rundir:\n",
+            "ln evidecen: 3.0000999470408543\n",
+            "ln evidence discarded: -5.6680552506499335\n",
+            "Using evidence_calibration code on same data (not noise):\n",
+            "ln evidecen: 3.0004031376317037\n",
+            "ln evidence discarded: -inf\n"
+          ]
+        }
+      ],
+      "source": [
+        "\n",
+        "print(\"From rundir:\")\n",
+        "summary_results = read_json(Path(rundir) / \"summary_results.json\")\n",
+        "print(\"ln evidence:\", summary_results[\"ln_evidence\"])\n",
+        "print(\"ln evidence discarded:\", summary_results[\"ln_evidence_discarded\"])\n",
+        "print(\"Using evidence_calibration code on same data (not noise):\")\n",
+        "print(\"ln evidence:\", ln_evidence)\n",
+        "print(\"ln evidence discarded:\", ln_evidence_discarded)"
+      ]
+    }
+  ],
+  "metadata": {
+    "kernelspec": {
+      "display_name": "dot-pe",
+      "language": "python",
+      "name": "python3"
+    },
+    "language_info": {
+      "codemirror_mode": {
+        "name": "ipython",
+        "version": 3
+      },
+      "file_extension": ".py",
+      "mimetype": "text/x-python",
+      "name": "python",
+      "nbconvert_exporter": "python",
+      "pygments_lexer": "ipython3",
+      "version": "3.13.5"
+    }
+  },
+  "nbformat": 4,
+  "nbformat_minor": 2
+}

--- a/scripts/test_evidence_calibration_on_event.py
+++ b/scripts/test_evidence_calibration_on_event.py
@@ -36,6 +36,11 @@ def main():
         action="store_true",
         help="Use cogwheel ASD models instead of event PSD (when creating noise)",
     )
+    parser.add_argument(
+        "--use-selected-inds",
+        action="store_true",
+        help="Load selection from intrinsic_samples.npz (default: use entire bank)",
+    )
     args = parser.parse_args()
 
     ln_evidence, ln_evidence_discarded = compute_evidence_on_noise(
@@ -43,6 +48,7 @@ def main():
         event_data_noise=args.noise,
         event_path=args.event,
         use_event_psd=not args.no_event_psd,
+        use_selected_inds=args.use_selected_inds,
         seed=args.seed,
     )
     print(f"ln_evidence = {ln_evidence:.6f}")

--- a/scripts/test_evidence_calibration_on_event.py
+++ b/scripts/test_evidence_calibration_on_event.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python3
+"""Test evidence calibration on an event (creates noise and runs compute_evidence_on_noise)."""
+
+import argparse
+import sys
+from pathlib import Path
+
+from dot_pe.evidence_calibration import compute_evidence_on_noise
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Test evidence calibration: create noise and compute ln_evidence."
+    )
+    parser.add_argument("rundir", type=Path, help="Path to completed inference rundir")
+    parser.add_argument(
+        "--event",
+        type=Path,
+        default=None,
+        help="Path to original event npz (when run_kwargs resolution fails)",
+    )
+    parser.add_argument(
+        "--noise",
+        type=Path,
+        default=None,
+        help="Path to pre-saved noise npz (skip creation, use this instead)",
+    )
+    parser.add_argument(
+        "--seed",
+        type=int,
+        default=None,
+        help="Random seed for noise",
+    )
+    parser.add_argument(
+        "--no-event-psd",
+        action="store_true",
+        help="Use cogwheel ASD models instead of event PSD (when creating noise)",
+    )
+    args = parser.parse_args()
+
+    ln_evidence, ln_evidence_discarded = compute_evidence_on_noise(
+        args.rundir,
+        event_data_noise=args.noise,
+        event_path=args.event,
+        use_event_psd=not args.no_event_psd,
+        seed=args.seed,
+    )
+    print(f"ln_evidence = {ln_evidence:.6f}")
+    print(f"ln_evidence_discarded = {ln_evidence_discarded:.6f}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_evidence_calibration.py
+++ b/tests/test_evidence_calibration.py
@@ -1,0 +1,26 @@
+"""Tests for evidence calibration (compute_evidence_on_noise)."""
+
+import pytest
+
+from cogwheel.data import EventData
+
+from dot_pe import config
+from dot_pe.evidence_calibration import compute_evidence_on_noise
+
+
+def test_compute_evidence_on_noise_raises_for_nonexistent_rundir(tmp_path):
+    """compute_evidence_on_noise raises FileNotFoundError for non-existent rundir."""
+    nonexistent = tmp_path / "nonexistent_rundir"
+    event_data = EventData.gaussian_noise("", **config.EVENT_DATA_KWARGS)
+    with pytest.raises(FileNotFoundError, match="Rundir not found"):
+        compute_evidence_on_noise(nonexistent, event_data)
+
+
+def test_compute_evidence_on_noise_raises_for_missing_posterior(tmp_path):
+    """compute_evidence_on_noise raises FileNotFoundError when Posterior.json is missing."""
+    # Create empty rundir (no Posterior.json)
+    rundir = tmp_path / "empty_rundir"
+    rundir.mkdir()
+    event_data = EventData.gaussian_noise("", **config.EVENT_DATA_KWARGS)
+    with pytest.raises(FileNotFoundError, match="Posterior.json not found"):
+        compute_evidence_on_noise(rundir, event_data)


### PR DESCRIPTION
Evidence Calibration

Compute ln_evidence on Gaussian noise using the same setup (par_dic_0, extrinsic samples, banks) from a completed inference rundir. Slim path only: no optimization, no sample storage, no size_limit.

Changes

- dot_pe/evidence_calibration.py (new): create_noise_event_data(rundir, ...) builds Gaussian noise from the event's PSD (wht_filter) or cogwheel asd_funcs. compute_evidence_on_noise(rundir, event_data_noise) recomputes ln_evidence using the rundir setup; no optimization; extrinsic samples loaded from rundir.
- notebooks/04_evidence_calibration/: new tutorial (mock data + bank, run inference, calibrate on noise, validate on same data).
- scripts/test_evidence_calibration_on_event.py, tests/test_evidence_calibration.py: script and unit tests.

Usage:
  noise_data = evidence_calibration.create_noise_event_data(rundir)
  ln_evidence, ln_evidence_discarded = evidence_calibration.compute_evidence_on_noise(rundir=rundir, event_data_noise=noise_data)