### PR TITLE
Add harmonic_modes to bank config with backward-compatible m_arr.

### DIFF
--- a/dot_pe/evidence_calibration.py
+++ b/dot_pe/evidence_calibration.py
@@ -24,7 +24,14 @@ from cogwheel.utils import read_json
 
 from . import likelihood_calculating, sample_processing
 from .likelihood_calculating import LinearFree
-from .utils import inds_to_blocks, parse_bank_folders, safe_logsumexp, validate_bank_configs
+from .utils import (
+    inds_to_blocks,
+    parse_bank_folders,
+    resolve_bank_modes,
+    safe_logsumexp,
+    validate_bank_configs,
+    waveform_generator_from_config,
+)
 
 # Threshold for dropping (i,e,o) combinations with approx lnlike below max - cut.
 # Large value = keep almost all non-negligible contributions.
@@ -193,24 +200,22 @@ def _compute_evidence_per_bank_slim(
     ln_evidence_discarded : float
         Always -np.inf (we do not track discarded in slim path).
     """
-    from cogwheel.waveform import WaveformGenerator
-
     bank_path = Path(bank_path)
     waveform_dir = bank_path / "waveforms"
     bank_file_path = bank_path / "intrinsic_sample_bank.feather"
     with open(bank_path / "bank_config.json", "r", encoding="utf-8") as f:
         bank_config = json.load(f)
         fbin = np.array(bank_config["fbin"])
-        approximant = bank_config["approximant"]
 
-    wfg = WaveformGenerator.from_event_data(event_data, approximant)
+    wfg = waveform_generator_from_config(event_data, bank_config)
     likelihood_linfree = LinearFree(event_data, wfg, par_dic_0, fbin)
 
     intrinsic_sample_processor = sample_processing.IntrinsicSampleProcessor(
         likelihood_linfree, waveform_dir
     )
+    _, resolved_m_arr = resolve_bank_modes(bank_config)
     likelihood_calc = likelihood_calculating.LikelihoodCalculator(
-        n_phi=n_phi, m_arr=np.array(m_arr)
+        n_phi=n_phi, m_arr=resolved_m_arr
     )
     dh_weights_dmpb, hh_weights_dmppb = intrinsic_sample_processor.get_summary()
 
@@ -441,7 +446,7 @@ def compute_evidence_on_noise(
     banks = parse_bank_folders(bank_folder)
     bank_paths = list(banks.values())
     bank_config = validate_bank_configs(bank_paths)
-    m_arr = np.array(bank_config["m_arr"])
+    _, m_arr = resolve_bank_modes(bank_config)
 
     n_ext = int(run_kwargs["n_ext"])
     n_phi = int(run_kwargs["n_phi"])

--- a/dot_pe/inference.py
+++ b/dot_pe/inference.py
@@ -37,7 +37,7 @@ from cogwheel.gw_utils import DETECTORS, get_geocenter_delays  # noqa: E402
 from cogwheel.likelihood import RelativeBinningLikelihood, LookupTable  # noqa: E402
 from cogwheel.posterior import Posterior  # noqa: E402
 from cogwheel.utils import exp_normalize, get_rundir, mkdirs, read_json  # noqa: E402
-from cogwheel.waveform import WaveformGenerator  # noqa: E402
+  # noqa: E402
 from cogwheel.prior import Prior  # noqa: E402
 from .base_sampler_free_sampling import (  # noqa: E402
     get_n_effective_total_i_e,
@@ -53,8 +53,10 @@ from .utils import (  # noqa: E402
     get_event_data,
     inds_to_blocks,
     parse_bank_folders,
+    resolve_bank_modes,
     safe_logsumexp,
     validate_bank_configs,
+    waveform_generator_from_config,
 )
 from .single_detector import SingleDetectorProcessor  # noqa: E402
 from .sample_processing import (  # noqa: E402
@@ -76,10 +78,13 @@ def _create_single_detector_processor(
     size_limit: int,
 ) -> SingleDetectorProcessor:
     """Create a SingleDetectorProcessor for a given detector."""
+    bank_folder = Path(bank_folder)
+    with open(bank_folder / "bank_config.json", "r", encoding="utf-8") as f:
+        bank_config = json.load(f)
     event_data_1d = extract_single_detector_event_data(event_data, det_name)
-    wfg = WaveformGenerator.from_event_data(event_data_1d, approximant)
+    wfg = waveform_generator_from_config(event_data_1d, bank_config)
     likelihood_linfree = LinearFree(event_data_1d, wfg, par_dic_0, fbin)
-    bank_file_path = Path(bank_folder) / "intrinsic_sample_bank.feather"
+    bank_file_path = bank_folder / "intrinsic_sample_bank.feather"
     waveform_dir = Path(bank_folder) / "waveforms"
 
     return SingleDetectorProcessor(
@@ -347,9 +352,8 @@ def run_coherent_inference(
     with open(bank_folder / "bank_config.json", "r", encoding="utf-8") as f:
         bank_config = json.load(f)
         fbin = np.array(bank_config["fbin"])
-        approximant = bank_config["approximant"]
 
-    wfg = WaveformGenerator.from_event_data(event_data, approximant)
+    wfg = waveform_generator_from_config(event_data, bank_config)
 
     likelihood_linfree = LinearFree(event_data, wfg, par_dic_0, fbin)
 
@@ -857,7 +861,7 @@ def prepare_run_objects(
     fbin = np.array(bank_config["fbin"])
     approximant = bank_config["approximant"]
     f_ref = bank_config["f_ref"]
-    m_arr = np.array(bank_config["m_arr"])
+    _harmonic_modes, m_arr = resolve_bank_modes(bank_config)
 
     print("Creating COGWHEEL objects...")
     coherent_posterior_kwargs = (
@@ -1235,7 +1239,9 @@ def draw_extrinsic_samples(
     first_bank_path = list(banks.values())[0]
     waveform_dir = first_bank_path / "waveforms"
     bank_file_path = first_bank_path / "intrinsic_sample_bank.feather"
-    wfg = WaveformGenerator.from_event_data(event_data, approximant)
+    with open(first_bank_path / "bank_config.json", "r", encoding="utf-8") as f:
+        first_bank_config = json.load(f)
+    wfg = waveform_generator_from_config(event_data, first_bank_config)
     marg_ext_like = MarginalizationExtrinsicSamplerFreeLikelihood(
         event_data, wfg, par_dic_0, fbin, coherent_score=coherent_score_kwargs
     )

--- a/dot_pe/single_detector.py
+++ b/dot_pe/single_detector.py
@@ -701,7 +701,7 @@ class SingleDetectorProcessor(JSONMixin, Loggable):
             timeshifts_dbt,
             self.likelihood.asd_drift,
             n_phi,
-            self.likelihood.waveform_generator.m_arr,
+            self.likelihood_calculator.m_arr,
         )
         return r_iotp, lnlike_iot
 

--- a/dot_pe/thin_coherent.py
+++ b/dot_pe/thin_coherent.py
@@ -76,10 +76,12 @@ def precompute_coherent_setup(
     bank_file_path = bank_path / "intrinsic_sample_bank.feather"
     waveform_dir = bank_path / "waveforms"
 
-    from cogwheel.waveform import WaveformGenerator
     from .likelihood_calculating import LinearFree
+    from .utils import waveform_generator_from_config
 
-    wfg = WaveformGenerator.from_event_data(event_data, approximant)
+    with open(bank_path / "bank_config.json", "r", encoding="utf-8") as f:
+        bank_config = json.load(f)
+    wfg = waveform_generator_from_config(event_data, bank_config)
     likelihood_linfree = LinearFree(event_data, wfg, par_dic_0, fbin)
 
     clp = CoherentLikelihoodProcessor(

--- a/dot_pe/utils.py
+++ b/dot_pe/utils.py
@@ -6,7 +6,7 @@ import gc
 import json
 import logging
 from pathlib import Path
-from typing import Dict, List, Tuple, Union
+from typing import Any, Dict, List, Sequence, Tuple, Union
 
 from numpy.typing import NDArray
 
@@ -20,6 +20,7 @@ from torch.types import Device
 from cogwheel.data import EventData
 from cogwheel import gw_utils
 from cogwheel.utils import read_json
+from cogwheel.waveform import APPROXIMANTS, WaveformGenerator
 
 
 def validate_q_bounds(q_min: float, q_max: float) -> None:
@@ -300,6 +301,122 @@ def sample_k_from_N(N, k):
     return arr[:k]
 
 
+def normalize_harmonic_modes(
+    harmonic_modes: Sequence[Sequence[int]],
+) -> List[Tuple[int, int]]:
+    """Convert JSON-style [[l, m], ...] to list of (l, m) tuples."""
+    return [tuple(int(x) for x in mode) for mode in harmonic_modes]
+
+
+def m_arr_from_harmonic_modes(
+    harmonic_modes: Sequence[Tuple[int, int]],
+) -> NDArray[np.int_]:
+    """
+    Unique m values in order of first appearance.
+
+    Order matches cogwheel ``WaveformGenerator``.
+    """
+    seen = []
+    for _l, m in harmonic_modes:
+        if m not in seen:
+            seen.append(m)
+    return np.asarray(seen, dtype=int)
+
+
+def default_harmonic_modes_for_approximant(
+    approximant: str,
+) -> List[Tuple[int, int]]:
+    """
+    Default (l, m) pairs for an approximant.
+
+    Same source as ``WaveformGenerator`` (``waveform.APPROXIMANTS``).
+    """
+    if approximant == "IMRPhenomXODE":
+        # Registers IMRPhenomXODE in APPROXIMANTS (side effect on import).
+        from cogwheel.waveform_models import xode as _  # noqa: F401
+
+    if approximant not in APPROXIMANTS:
+        raise ValueError(
+            f"Unknown approximant {approximant!r}; "
+            "add it to cogwheel.waveform.APPROXIMANTS."
+        )
+    return [tuple(mode) for mode in APPROXIMANTS[approximant].harmonic_modes]
+
+
+def harmonic_modes_from_config(
+    bank_config: Dict[str, Any],
+) -> List[Tuple[int, int]]:
+    """
+    Resolve harmonic_modes from bank config.
+
+    If harmonic_modes is present, use it. Otherwise filter the approximant's
+    default modes to those with m in bank_config['m_arr'] (legacy banks).
+    """
+    if "harmonic_modes" in bank_config:
+        return normalize_harmonic_modes(bank_config["harmonic_modes"])
+
+    approximant = bank_config["approximant"]
+    if "m_arr" not in bank_config:
+        raise ValueError("bank_config must contain 'harmonic_modes' or 'm_arr'")
+    m_allowed = set(int(m) for m in bank_config["m_arr"])
+    return [
+        mode
+        for mode in default_harmonic_modes_for_approximant(approximant)
+        if mode[1] in m_allowed
+    ]
+
+
+def resolve_bank_modes(
+    bank_config: Dict[str, Any],
+) -> Tuple[List[Tuple[int, int]], NDArray[np.int_]]:
+    """
+    Return (harmonic_modes, m_arr) for a bank config.
+
+    Legacy (m_arr only): returned m_arr equals config m_arr unchanged.
+
+    New (harmonic_modes): m_arr is derived; if m_arr is also present it must
+    match.
+    """
+    harmonic_modes = harmonic_modes_from_config(bank_config)
+    derived_m_arr = m_arr_from_harmonic_modes(harmonic_modes)
+
+    if "harmonic_modes" in bank_config:
+        if "m_arr" in bank_config:
+            config_m_arr = np.asarray(bank_config["m_arr"], dtype=int)
+            if not np.array_equal(config_m_arr, derived_m_arr):
+                raise ValueError(
+                    "bank_config m_arr does not match m values derived from "
+                    f"harmonic_modes: config {config_m_arr.tolist()}, "
+                    f"derived {derived_m_arr.tolist()}"
+                )
+        return harmonic_modes, derived_m_arr
+
+    return harmonic_modes, np.asarray(bank_config["m_arr"], dtype=int)
+
+
+def harmonic_modes_to_json(
+    harmonic_modes: Sequence[Sequence[int]],
+) -> List[List[int]]:
+    """Serialize harmonic_modes for bank_config.json."""
+    normalized = normalize_harmonic_modes(harmonic_modes)
+    return [[int(l), int(m)] for l, m in normalized]
+
+
+def waveform_generator_from_config(
+    event_data: EventData,
+    bank_config: Dict[str, Any],
+    **kwargs,
+) -> WaveformGenerator:
+    """Build WaveformGenerator using modes resolved from bank_config."""
+    harmonic_modes, _ = resolve_bank_modes(bank_config)
+    return WaveformGenerator.from_event_data(
+        event_data,
+        bank_config["approximant"],
+        harmonic_modes=harmonic_modes,
+        **kwargs,
+    )
+
+
 def validate_bank_configs(bank_paths: List[Path]) -> Dict:
     """
     Validate that all bank configs match on critical parameters.
@@ -337,6 +454,9 @@ def validate_bank_configs(bank_paths: List[Path]) -> Dict:
     ref_fbin = np.array(ref_config["fbin"])
     ref_f_ref = ref_config["f_ref"]
     ref_m_arr = np.array(ref_config["m_arr"])
+    ref_has_harmonic_modes = "harmonic_modes" in ref_config
+    if ref_has_harmonic_modes:
+        ref_harmonic_modes = harmonic_modes_from_config(ref_config)
 
     # Validate against reference (q_min/q_max are intentionally not checked:
     # regular banks and low-q banks have non-overlapping q ranges by design)
@@ -363,6 +483,23 @@ def validate_bank_configs(bank_paths: List[Path]) -> Dict:
             errors.append(
                 f"m_arr mismatch: bank {i} has different m_arr than reference"
             )
+
+        if ref_has_harmonic_modes:
+            if "harmonic_modes" not in config:
+                errors.append(
+                    f"harmonic_modes missing: bank {i} has no harmonic_modes "
+                    "but reference bank does"
+                )
+            elif harmonic_modes_from_config(config) != ref_harmonic_modes:
+                errors.append(
+                    f"harmonic_modes mismatch: bank {i} has different "
+                    "harmonic_modes than reference"
+                )
+            _, derived_m = resolve_bank_modes(config)
+            if not np.array_equal(derived_m, np.array(config["m_arr"])):
+                errors.append(
+                    f"bank {i}: m_arr inconsistent with harmonic_modes"
+                )
 
         if errors:
             error_msg = "Bank config validation failed:\n" + "\n".join(errors)

--- a/dot_pe/vetoing.py
+++ b/dot_pe/vetoing.py
@@ -22,7 +22,11 @@ from cogwheel.utils import get_rundir, mkdirs, NumpyEncoder
 from cogwheel.waveform import WaveformGenerator
 
 from .likelihood_calculating import LinearFree
-from .utils import get_event_data
+from .utils import (
+    get_event_data,
+    resolve_bank_modes,
+    waveform_generator_from_config,
+)
 from .single_detector import SingleDetectorProcessor
 
 
@@ -350,11 +354,10 @@ def get_block_likelihood(
     waveform_dir = bank_folder / "waveforms"
     with open(bank_folder / "bank_config.json", "r") as f:
         bank_config = json.load(f)
-        approximant = bank_config["approximant"]
         fbin = np.array([bank_config["fbin"]])
-        m_arr = np.array(bank_config["m_arr"])
+    _, m_arr = resolve_bank_modes(bank_config)
     event_data = get_event_data(event)
-    wfg = WaveformGenerator.from_event_data(event_data, approximant=approximant)
+    wfg = waveform_generator_from_config(event_data, bank_config)
 
     likelihood_linfree = LinearFree(event_data, wfg, par_dic_0, fbin)
     block_likelihood = SingleDetectorProcessor(

--- a/dot_pe/waveform_banks.py
+++ b/dot_pe/waveform_banks.py
@@ -17,7 +17,11 @@ from cogwheel import data, waveform
 from cogwheel.utils import mkdirs
 
 from . import config
-from .utils import setup_logger
+from .utils import (
+    harmonic_modes_to_json,
+    setup_logger,
+    waveform_generator_from_config,
+)
 
 
 def get_waveform(wfg, int_dic, fbin, override_dic=None):
@@ -223,6 +227,7 @@ def create_waveform_bank_from_samples(
     i_end=None,
     i_list=None,
     approximant="IMRPhenomXODE",
+    harmonic_modes=None,
 ):
     """
     Load a sample bank from a feather file, generate linear-free time
@@ -257,16 +262,24 @@ def create_waveform_bank_from_samples(
             config_dict = json.load(fp)
             fbin = np.array(config_dict["fbin"])
             f_ref = config_dict["f_ref"]
+            config_dict.setdefault("approximant", approximant)
     else:
         fbin = config.DEFAULT_FBIN
         f_ref = config.DEFAULT_F_REF
+        config_dict = {"approximant": approximant}
+
+    if harmonic_modes is not None:
+        config_dict["harmonic_modes"] = harmonic_modes_to_json(harmonic_modes)
+        if bank_config_path is not None:
+            with open(bank_config_path, "w", encoding="utf-8") as fp:
+                json.dump(config_dict, fp, indent=4)
 
     intrinsic_samples = pd.read_feather(samples_path)
     event_data = data.EventData.gaussian_noise("", **config.EVENT_DATA_KWARGS)
 
     # access waveform.APPROXIMANTS only after wfg is created, due to
     # importing scheme. May crash otherwise.
-    wfg = waveform.WaveformGenerator.from_event_data(event_data, approximant)
+    wfg = waveform_generator_from_config(event_data, config_dict)
     if waveform.APPROXIMANTS[approximant].aligned_spins:
         intrinsic_samples[["s1x_n", "s1y_n", "s2x_n", "s2y_n"]] = 0.0
         intrinsic_samples.to_feather(samples_path)
@@ -325,14 +338,16 @@ def create_waveform_bank_from_samples(
         + f"{runtime_seconds:.3g} seconds "
         + f"({runtime_minutes:.3g} minutes)."
     )
-    with open(bank_config_path, "r", encoding="utf-8") as fp:
-        config_dict = json.load(fp)
-    config_dict["approximant"] = approximant
-    config_dict["m_arr"] = wfg.m_arr.tolist()
-    config_dict["blocksize"] = blocksize
+    if bank_config_path is not None:
+        with open(bank_config_path, "r", encoding="utf-8") as fp:
+            config_dict = json.load(fp)
+        config_dict["approximant"] = approximant
+        config_dict["harmonic_modes"] = harmonic_modes_to_json(wfg.harmonic_modes)
+        config_dict["m_arr"] = wfg.m_arr.tolist()
+        config_dict["blocksize"] = blocksize
 
-    with open(bank_config_path, "w", encoding="utf-8") as fp:
-        json.dump(config_dict, fp, indent=4)
+        with open(bank_config_path, "w", encoding="utf-8") as fp:
+            json.dump(config_dict, fp, indent=4)
 
 
 def submit_to_lsf(

--- a/tests/test_bank_harmonic_modes.py
+++ b/tests/test_bank_harmonic_modes.py
@@ -1,0 +1,357 @@
+"""Tests for bank harmonic_modes and backward-compatible m_arr fallback."""
+
+import json
+from pathlib import Path
+from typing import List, Optional
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from cogwheel.waveform import WaveformGenerator
+
+from dot_pe import config, waveform_banks
+from dot_pe.utils import (
+    normalize_harmonic_modes,
+    resolve_bank_modes,
+    waveform_generator_from_config,
+)
+
+
+def test_resolve_explicit_harmonic_modes_22_only():
+    bank_config = {
+        "approximant": "IMRPhenomXODE",
+        "harmonic_modes": [[2, 2]],
+    }
+    harmonic_modes, m_arr = resolve_bank_modes(bank_config)
+    assert harmonic_modes == [(2, 2)]
+    assert list(m_arr) == [2]
+
+
+def test_resolve_legacy_m_arr_only_unchanged():
+    legacy_m = [2, 1, 3, 4]
+    bank_config = {
+        "approximant": "IMRPhenomXPHM",
+        "m_arr": legacy_m,
+    }
+    harmonic_modes, m_arr = resolve_bank_modes(bank_config)
+    assert list(m_arr) == legacy_m
+    assert "harmonic_modes" not in bank_config
+    allowed = set(legacy_m)
+    for l, m in harmonic_modes:
+        assert m in allowed
+    assert (3, 3) in harmonic_modes
+    assert (3, 2) in harmonic_modes
+
+
+def test_legacy_harmonic_modes_match_wfg_m_arr():
+    bank_config = {
+        "approximant": "IMRPhenomXPHM",
+        "m_arr": [2, 1, 3, 4],
+    }
+    harmonic_modes, m_arr = resolve_bank_modes(bank_config)
+    from cogwheel.data import EventData
+
+    ed = EventData.gaussian_noise("", **config.EVENT_DATA_KWARGS)
+    wfg = WaveformGenerator.from_event_data(
+        ed, bank_config["approximant"], harmonic_modes=harmonic_modes
+    )
+    assert np.array_equal(wfg.m_arr, m_arr)
+
+
+def test_both_fields_must_be_consistent():
+    bank_config = {
+        "approximant": "IMRPhenomXODE",
+        "harmonic_modes": [[2, 2]],
+        "m_arr": [2, 1],
+    }
+    with pytest.raises(ValueError, match="does not match"):
+        resolve_bank_modes(bank_config)
+
+
+def test_normalize_harmonic_modes():
+    assert normalize_harmonic_modes([[2, 2], (2, 1)]) == [(2, 2), (2, 1)]
+
+
+def _minimal_bank_samples(n=8):
+    rng = np.random.default_rng(0)
+    return pd.DataFrame(
+        {
+            "m1": 30.0 + rng.normal(size=n),
+            "m2": 25.0 + rng.normal(size=n),
+            "s1z": rng.normal(size=n) * 0.1,
+            "s1x_n": np.zeros(n),
+            "s1y_n": np.zeros(n),
+            "s2z": rng.normal(size=n) * 0.1,
+            "s2x_n": np.zeros(n),
+            "s2y_n": np.zeros(n),
+            "iota": np.pi / 3 + rng.normal(size=n) * 0.05,
+            "log_prior_weights": np.zeros(n),
+        }
+    )
+
+
+@pytest.mark.integration
+def test_single_mode_bank_waveforms_and_sdp(tmp_path):
+    """Tiny (2,2)-only bank: waveform shape and SDP weights match one mode."""
+    pytest.importorskip("lalsimulation")
+
+    bank_dir = tmp_path / "bank_22"
+    bank_dir.mkdir()
+    n = 8
+    blocksize = 8
+    samples_path = bank_dir / "intrinsic_sample_bank.feather"
+    _minimal_bank_samples(n).to_feather(samples_path)
+
+    bank_config = {
+        "fbin": config.DEFAULT_FBIN.tolist(),
+        "f_ref": 50.0,
+        "approximant": "IMRPhenomXODE",
+        "harmonic_modes": [[2, 2]],
+    }
+    bank_config_path = bank_dir / "bank_config.json"
+    with open(bank_config_path, "w") as f:
+        json.dump(bank_config, f)
+
+    waveform_dir = bank_dir / "waveforms"
+    waveform_banks.create_waveform_bank_from_samples(
+        samples_path=samples_path,
+        bank_config_path=bank_config_path,
+        waveform_dir=waveform_dir,
+        n_pool=1,
+        blocksize=blocksize,
+        approximant="IMRPhenomXODE",
+    )
+
+    with open(bank_config_path) as f:
+        saved = json.load(f)
+    assert "harmonic_modes" in saved
+    assert saved["harmonic_modes"] == [[2, 2]]
+    assert saved["m_arr"] == [2]
+
+    amp = np.load(waveform_dir / "amplitudes_block_0.npy")
+    assert amp.shape[1] == 1
+
+    from cogwheel.data import EventData
+    from cogwheel.posterior import Posterior
+    from dot_pe.inference import _create_single_detector_processor
+
+    event_data = EventData.gaussian_noise("", **config.EVENT_DATA_KWARGS)
+    posterior = Posterior.from_event(
+        event=event_data,
+        mchirp_guess=25.0,
+        likelihood_kwargs={
+            "fbin": np.array(saved["fbin"]),
+            "pn_phase_tol": None,
+        },
+        approximant="IMRPhenomXODE",
+        prior_class="CartesianIASPrior",
+    )
+    par_dic_0 = posterior.likelihood.par_dic_0.copy()
+    _, m_arr = resolve_bank_modes(saved)
+    sdp = _create_single_detector_processor(
+        event_data,
+        "H",
+        par_dic_0,
+        bank_dir,
+        np.array(saved["fbin"]),
+        "IMRPhenomXODE",
+        16,
+        m_arr,
+        blocksize,
+        10**6,
+    )
+    assert sdp.dh_weights_dmpb.shape[1] == 1
+    assert len(sdp.likelihood_calculator.m_arr) == 1
+
+
+def test_waveform_generator_from_config_matches_cogwheel():
+    from dot_pe.utils import default_harmonic_modes_for_approximant
+
+    bank_config = {
+        "approximant": "IMRPhenomXPHM",
+        "m_arr": [2, 1, 3, 4],
+    }
+    from cogwheel.data import EventData
+
+    ed = EventData.gaussian_noise("", **config.EVENT_DATA_KWARGS)
+    wfg = waveform_generator_from_config(ed, bank_config)
+    default_modes = [
+        m
+        for m in default_harmonic_modes_for_approximant("IMRPhenomXPHM")
+        if m[1] in {2, 1, 3, 4}
+    ]
+    assert list(wfg.harmonic_modes) == default_modes
+
+
+def test_legacy_xode_m_arr_fallback():
+    from dot_pe.utils import default_harmonic_modes_for_approximant
+
+    bank_config = {"approximant": "IMRPhenomXODE", "m_arr": [2, 1, 3, 4]}
+    harmonic_modes, m_arr = resolve_bank_modes(bank_config)
+    assert list(m_arr) == [2, 1, 3, 4]
+    allowed = {2, 1, 3, 4}
+    for mode in harmonic_modes:
+        assert mode[1] in allowed
+    xode_modes = default_harmonic_modes_for_approximant("IMRPhenomXODE")
+    n_xode = len([m for m in xode_modes if m[1] in allowed])
+    assert len(harmonic_modes) == n_xode
+
+
+# --- Fast inference smoke tests (small bank + small blocks + capped n_int) ---
+
+SMALL_BANK_SIZE = 64
+SMALL_BLOCKSIZE = 64
+SMALL_N_INT = 32
+SMALL_N_EXT = 4
+SMALL_N_PHI = 8
+SMALL_N_T = 16
+SMALL_APPROXIMANT = "IMRPhenomXODE"
+
+
+def _create_small_bank(
+    tmp_path: Path,
+    name: str,
+    *,
+    legacy_m_arr_only: bool,
+    harmonic_modes: Optional[List] = None,
+    m_arr: Optional[List] = None,
+    bank_size: int = SMALL_BANK_SIZE,
+    blocksize: int = SMALL_BLOCKSIZE,
+) -> Path:
+    """
+    Build a tiny bank.
+
+    If legacy_m_arr_only, config has m_arr only (pre-change style).
+    """
+    bank_dir = tmp_path / name
+    bank_dir.mkdir()
+    samples_path = bank_dir / "intrinsic_sample_bank.feather"
+    _minimal_bank_samples(bank_size).to_feather(samples_path)
+
+    bank_config = {
+        "bank_size": bank_size,
+        "fbin": config.DEFAULT_FBIN.tolist(),
+        "f_ref": 50.0,
+        "approximant": SMALL_APPROXIMANT,
+        "blocksize": blocksize,
+    }
+    if legacy_m_arr_only:
+        bank_config["m_arr"] = m_arr if m_arr is not None else [2, 1, 3, 4]
+    else:
+        if harmonic_modes is None:
+            raise ValueError(
+                "harmonic_modes required when not legacy_m_arr_only"
+            )
+        bank_config["harmonic_modes"] = harmonic_modes
+        if m_arr is not None:
+            bank_config["m_arr"] = m_arr
+
+    bank_config_path = bank_dir / "bank_config.json"
+    with open(bank_config_path, "w", encoding="utf-8") as f:
+        json.dump(bank_config, f, indent=2)
+
+    waveform_banks.create_waveform_bank_from_samples(
+        samples_path=samples_path,
+        bank_config_path=bank_config_path,
+        waveform_dir=bank_dir / "waveforms",
+        n_pool=1,
+        blocksize=blocksize,
+        approximant=SMALL_APPROXIMANT,
+        harmonic_modes=None if legacy_m_arr_only else harmonic_modes,
+    )
+    return bank_dir
+
+
+def _run_small_inference(
+    tmp_path: Path,
+    bank_dir: Path,
+    rundir_name: str,
+) -> dict:
+    from cogwheel.data import EventData
+
+    from dot_pe import inference
+
+    event_data = EventData.gaussian_noise("", **config.EVENT_DATA_KWARGS)
+    rundir = tmp_path / rundir_name
+    inference.run(
+        event=event_data,
+        bank_folder=bank_dir,
+        n_int=SMALL_N_INT,
+        n_ext=SMALL_N_EXT,
+        n_phi=SMALL_N_PHI,
+        n_t=SMALL_N_T,
+        blocksize=SMALL_BLOCKSIZE,
+        single_detector_blocksize=SMALL_BLOCKSIZE,
+        rundir=rundir,
+        mchirp_guess=25.0,
+        max_incoherent_lnlike_drop=20,
+        max_bestfit_lnlike_diff=20,
+        coherent_score_min_n_effective_prior=0,
+        draw_subset=False,
+        seed=42,
+    )
+    with open(rundir / "summary_results.json", encoding="utf-8") as f:
+        summary = json.load(f)
+    assert np.isfinite(summary["ln_evidence"]), summary
+    assert summary.get("n_effective", 0) >= 0
+    return summary
+
+
+@pytest.mark.integration
+def test_inference_legacy_m_arr_only_bank(tmp_path):
+    """Legacy bank_config (m_arr only) through full inference.run."""
+    pytest.importorskip("lalsimulation")
+    bank_dir = _create_small_bank(
+        tmp_path, "bank_legacy", legacy_m_arr_only=True, m_arr=[2, 1, 3, 4]
+    )
+    with open(bank_dir / "bank_config.json", encoding="utf-8") as f:
+        saved = json.load(f)
+    assert saved["m_arr"] == [2, 1, 3, 4]
+    assert "harmonic_modes" in saved
+    amp = np.load(bank_dir / "waveforms" / "amplitudes_block_0.npy")
+    assert amp.shape == (SMALL_BANK_SIZE, 4, 2, len(config.DEFAULT_FBIN))
+    _run_small_inference(tmp_path, bank_dir, "run_legacy")
+
+
+@pytest.mark.integration
+def test_inference_explicit_harmonic_modes_bank(tmp_path):
+    """New scheme: harmonic_modes in config from the start (full mode set)."""
+    pytest.importorskip("lalsimulation")
+    from dot_pe.utils import default_harmonic_modes_for_approximant
+
+    default_modes = default_harmonic_modes_for_approximant(SMALL_APPROXIMANT)
+    hm = [[l, m] for l, m in default_modes]
+    bank_dir = _create_small_bank(
+        tmp_path,
+        "bank_hm",
+        legacy_m_arr_only=False,
+        harmonic_modes=hm,
+        m_arr=[2, 1, 3, 4],
+    )
+    with open(bank_dir / "bank_config.json", encoding="utf-8") as f:
+        saved = json.load(f)
+    assert saved["harmonic_modes"] == hm
+    assert saved["m_arr"] == [2, 1, 3, 4]
+    amp = np.load(bank_dir / "waveforms" / "amplitudes_block_0.npy")
+    assert amp.shape[1] == 4
+    _run_small_inference(tmp_path, bank_dir, "run_hm")
+
+
+@pytest.mark.integration
+def test_inference_single_mode_harmonic_modes_bank(tmp_path):
+    """New scheme: (2,2)-only bank through inference.run."""
+    pytest.importorskip("lalsimulation")
+    bank_dir = _create_small_bank(
+        tmp_path,
+        "bank_22",
+        legacy_m_arr_only=False,
+        harmonic_modes=[[2, 2]],
+    )
+    with open(bank_dir / "bank_config.json", encoding="utf-8") as f:
+        saved = json.load(f)
+    assert saved["m_arr"] == [2]
+    amp = np.load(bank_dir / "waveforms" / "amplitudes_block_0.npy")
+    assert amp.shape[1] == 1
+    _run_small_inference(tmp_path, bank_dir, "run_22")
+


### PR DESCRIPTION
Store and resolve modes from bank_config.json so WaveformGenerator matches stored waveforms. Legacy banks with m_arr only still work by filtering APPROXIMANTS defaults. Includes fast inference smoke tests.